### PR TITLE
Add TraceLogger to record traces for retrieve requests.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,11 @@
             <version>4.1</version>
         </dependency>
         <dependency>
+            <groupId>commons-net</groupId>
+            <artifactId>commons-net</artifactId>
+            <version>3.10.0</version>
+        </dependency>
+        <dependency>
             <groupId>com.github.dnsjava</groupId>
             <artifactId>dnsjava</artifactId>
             <version>v3.5.2</version>

--- a/src/main/java/org/peergos/Client.java
+++ b/src/main/java/org/peergos/Client.java
@@ -12,6 +12,7 @@ import org.peergos.protocol.http.*;
 import org.peergos.util.JSONParser;
 import org.peergos.util.JsonHelper;
 import org.peergos.util.Logging;
+import org.peergos.util.TraceLogger;
 
 import java.io.File;
 import java.io.IOException;
@@ -69,6 +70,8 @@ public class Client {
 
         System.out.println("Started client: " + args.getArg("id"));
         Scanner scanner = new Scanner(System.in);
+        TraceLogger traceLogger = TraceLogger.getInstance();
+        traceLogger.setIdentity(config.identity.peerId);
         while (true) {
             System.out.print("Publish (P) or Retrieve (R)? ");
             String opt = scanner.nextLine();
@@ -79,11 +82,20 @@ public class Client {
                 Cid cid = ipfs.blockstore.put(contentBytes, Codec.Raw).join();
                 System.out.println("Cid: " + cid.toString());
             } else if (opt.toUpperCase().equals("R")) {
-                System.out.print("Enter Cid to retrieve: ");
-                String cid = scanner.nextLine();
-                Want want = new Want(Cid.decode(cid));
-                List<HashedBlock> blocks = ipfs.getBlocks(List.of(want), new HashSet<PeerId>(), false);
-                System.out.println("Content: " + new String(blocks.get(0).block, StandardCharsets.UTF_8));
+                // Start a new thread to build a new context.
+                Thread retriverThread = new Thread(new Runnable() {
+                    public void run() {
+                        System.out.print("Enter Cid to retrieve: ");
+                        String cid = scanner.nextLine();
+                        Want want = new Want(Cid.decode(cid));
+                        traceLogger.startTrace();
+                        List<HashedBlock> blocks = ipfs.getBlocks(List.of(want), new HashSet<PeerId>(), false);
+                        System.out.println("Content: " + new String(blocks.get(0).block, StandardCharsets.UTF_8));
+                        traceLogger.endTrace();
+                    }
+                });
+                retriverThread.start();
+                retriverThread.join();
             } else {
                 System.out.println("Try again");
             }

--- a/src/main/java/org/peergos/Client.java
+++ b/src/main/java/org/peergos/Client.java
@@ -83,7 +83,7 @@ public class Client {
                 System.out.println("Cid: " + cid.toString());
             } else if (opt.toUpperCase().equals("R")) {
                 // Start a new thread to build a new context.
-                Thread retriverThread = new Thread(new Runnable() {
+                Thread retrieverThread = new Thread(new Runnable() {
                     public void run() {
                         System.out.print("Enter Cid to retrieve: ");
                         String cid = scanner.nextLine();
@@ -94,8 +94,8 @@ public class Client {
                         traceLogger.endTrace();
                     }
                 });
-                retriverThread.start();
-                retriverThread.join();
+                retrieverThread.start();
+                retrieverThread.join();
             } else {
                 System.out.println("Try again");
             }

--- a/src/main/java/org/peergos/blockstore/RamBlockstore.java
+++ b/src/main/java/org/peergos/blockstore/RamBlockstore.java
@@ -28,7 +28,6 @@ public class RamBlockstore implements Blockstore {
 
     @Override
     public CompletableFuture<Optional<byte[]>> get(Cid c) {
-        System.out.println("Returning blocks from RAM for cid: " + c.toString());
         return CompletableFuture.completedFuture(Optional.ofNullable(blocks.get(c)));
     }
 

--- a/src/main/java/org/peergos/protocol/bitswap/Bitswap.java
+++ b/src/main/java/org/peergos/protocol/bitswap/Bitswap.java
@@ -75,7 +75,6 @@ public class Bitswap extends StrictProtocolBinding<BitswapController> implements
             CompletableFuture<HashedBlock> res = engine.getWant(w, addToBlockstore);
             results.add(res);
         }
-        System.out.println("Send wants started: " + wants.size());
         sendWants(us, peers);
         DownloadManager manager = downloads.getOrDefault(peers, new DownloadManager(us, peers));
         manager.ensureRunning();

--- a/src/main/java/org/peergos/protocol/bitswap/BitswapConnection.java
+++ b/src/main/java/org/peergos/protocol/bitswap/BitswapConnection.java
@@ -4,6 +4,7 @@ import io.libp2p.core.Stream;
 import io.prometheus.client.*;
 import kotlin.*;
 import org.peergos.protocol.bitswap.pb.*;
+import org.peergos.util.TraceLogger;
 
 import java.util.concurrent.*;
 
@@ -19,6 +20,7 @@ public class BitswapConnection implements BitswapController {
 
     @Override
     public void send(MessageOuterClass.Message msg) {
+        msg = TraceLogger.getInstance().HandleBitswapClientStart(msg, conn.remotePeerId());
         conn.writeAndFlush(msg);
         sentBytes.inc(msg.getSerializedSize());
     }

--- a/src/main/java/org/peergos/protocol/bitswap/BitswapEngine.java
+++ b/src/main/java/org/peergos/protocol/bitswap/BitswapEngine.java
@@ -30,14 +30,16 @@ public class BitswapEngine {
     private final ConcurrentHashMap<Want, Boolean> persistBlocks = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<Want, PeerId> blockHaves = new ConcurrentHashMap<>();
     private final Map<Want, Boolean> deniedWants = Collections.synchronizedMap(new LRUCache<>(10_000));
-    private final Map<PeerId, Map<Want, Long>> recentWantsSent = Collections.synchronizedMap(new org.peergos.util.LRUCache<>(100));
+    private final Map<PeerId, Map<Want, Long>> recentWantsSent = Collections
+            .synchronizedMap(new org.peergos.util.LRUCache<>(100));
     private final Map<PeerId, Boolean> blockedPeers = Collections.synchronizedMap(new LRUCache<>(1_000));
     private final boolean blockAggressivePeers;
     private final Set<PeerId> connections = new HashSet<>();
     private final BlockRequestAuthoriser authoriser;
     private AddressBook addressBook;
 
-    public BitswapEngine(Blockstore store, BlockRequestAuthoriser authoriser, int maxMessageSize, boolean blockAggressivePeers) {
+    public BitswapEngine(Blockstore store, BlockRequestAuthoriser authoriser, int maxMessageSize,
+            boolean blockAggressivePeers) {
         this.store = store;
         this.authoriser = authoriser;
         this.maxMessageSize = maxMessageSize;
@@ -48,13 +50,12 @@ public class BitswapEngine {
         this(store, authoriser, maxMessageSize, false);
     }
 
-
     public int maxMessageSize() {
         return maxMessageSize;
     }
 
     public boolean allowConnection(PeerId peer) {
-        return ! blockAggressivePeers || ! blockedPeers.containsKey(peer);
+        return !blockAggressivePeers || !blockedPeers.containsKey(peer);
     }
 
     public void setAddressBook(AddressBook addrs) {
@@ -77,7 +78,7 @@ public class BitswapEngine {
     }
 
     public boolean hasWants() {
-        return ! localWants.isEmpty();
+        return !localWants.isEmpty();
     }
 
     public Set<PeerId> getConnected() {
@@ -114,9 +115,9 @@ public class BitswapEngine {
             long now = System.currentTimeMillis();
             long minResendWait = 5_000;
             Set<Want> res = localWants.entrySet().stream()
-                    .filter(e -> e.getValue().creationTime > now - 5*60*1000)
+                    .filter(e -> e.getValue().creationTime > now - 5 * 60 * 1000)
                     .map(e -> e.getKey())
-                    .filter(w -> ! recent.containsKey(w) || recent.get(w) < now - minResendWait)
+                    .filter(w -> !recent.containsKey(w) || recent.get(w) < now - minResendWait)
                     .collect(Collectors.toSet());
             res.forEach(w -> recent.put(w, now));
             return res;
@@ -134,7 +135,8 @@ public class BitswapEngine {
             Cid.putUvarint(res, c.version);
             Cid.putUvarint(res, c.codec.type);
             Cid.putUvarint(res, c.getType().index);
-            Cid.putUvarint(res, c.getType().length);;
+            Cid.putUvarint(res, c.getType().length);
+            ;
             return res.toByteArray();
         } catch (IOException e) {
             throw new RuntimeException(e);
@@ -142,20 +144,21 @@ public class BitswapEngine {
     }
 
     public void receiveMessage(MessageOuterClass.Message msg, Stream source, Counter sentBytes) {
+        // TODO(sonudoo): This logging should be performed by handler. Requires some
+        // code refactoring.
+        TraceLogger.getInstance().HandleBitswapReceive(msg, source.remotePeerId());
         List<MessageOuterClass.Message.BlockPresence> presences = new ArrayList<>();
         List<MessageOuterClass.Message.Block> blocks = new ArrayList<>();
-
         int messageSize = 0;
         Multihash peerM = Multihash.deserialize(source.remotePeerId().getBytes());
         Cid sourcePeerId = new Cid(1, Cid.Codec.Libp2pKey, peerM.getType(), peerM.getHash());
         int absentBlocks = 0;
         int presentBlocks = 0;
         if (msg.hasWantlist()) {
-            System.out.println("Bitswap received request for wants: ");
             for (MessageOuterClass.Message.Wantlist.Entry e : msg.getWantlist().getEntriesList()) {
                 Cid c = Cid.cast(e.getBlock().toByteArray());
-                System.out.println("Want: " + c.toString());
-                Optional<String> auth = e.getAuth().isEmpty() ? Optional.empty() : Optional.of(ArrayOps.bytesToHex(e.getAuth().toByteArray()));
+                Optional<String> auth = e.getAuth().isEmpty() ? Optional.empty()
+                        : Optional.of(ArrayOps.bytesToHex(e.getAuth().toByteArray()));
                 boolean isCancel = e.getCancel();
                 boolean sendDontHave = e.getSendDontHave();
                 boolean wantBlock = e.getWantType().getNumber() == 0;
@@ -163,7 +166,8 @@ public class BitswapEngine {
                 if (wantBlock) {
                     boolean denied = deniedWants.containsKey(w);
                     if (denied) {
-                        MessageOuterClass.Message.BlockPresence presence = MessageOuterClass.Message.BlockPresence.newBuilder()
+                        MessageOuterClass.Message.BlockPresence presence = MessageOuterClass.Message.BlockPresence
+                                .newBuilder()
                                 .setCid(ByteString.copyFrom(c.toBytes()))
                                 .setType(MessageOuterClass.Message.BlockPresenceType.DontHave)
                                 .build();
@@ -172,7 +176,7 @@ public class BitswapEngine {
                         continue;
                     }
                     boolean blockPresent = store.has(c).join();
-                    if (! blockPresent)
+                    if (!blockPresent)
                         absentBlocks++;
                     else
                         presentBlocks++;
@@ -196,7 +200,8 @@ public class BitswapEngine {
                             deniedWants.put(w, true);
                             LOG.info("Rejecting auth for block " + c + " from " + sourcePeerId.bareMultihash());
                         }
-                        MessageOuterClass.Message.BlockPresence presence = MessageOuterClass.Message.BlockPresence.newBuilder()
+                        MessageOuterClass.Message.BlockPresence presence = MessageOuterClass.Message.BlockPresence
+                                .newBuilder()
                                 .setCid(ByteString.copyFrom(c.toBytes()))
                                 .setType(MessageOuterClass.Message.BlockPresenceType.DontHave)
                                 .build();
@@ -204,19 +209,22 @@ public class BitswapEngine {
                         messageSize += presence.getSerializedSize();
                     } else if (blockPresent) {
                         deniedWants.put(w, true);
-                        LOG.info("Rejecting repeated invalid auth for block " + c + " from " + sourcePeerId.bareMultihash());
+                        LOG.info("Rejecting repeated invalid auth for block " + c + " from "
+                                + sourcePeerId.bareMultihash());
                     }
                 } else {
                     boolean hasBlock = store.has(c).join();
                     if (hasBlock) {
-                        MessageOuterClass.Message.BlockPresence presence = MessageOuterClass.Message.BlockPresence.newBuilder()
+                        MessageOuterClass.Message.BlockPresence presence = MessageOuterClass.Message.BlockPresence
+                                .newBuilder()
                                 .setCid(ByteString.copyFrom(c.toBytes()))
                                 .setType(MessageOuterClass.Message.BlockPresenceType.Have)
                                 .build();
                         presences.add(presence);
                         messageSize += presence.getSerializedSize();
                     } else if (sendDontHave) {
-                        MessageOuterClass.Message.BlockPresence presence = MessageOuterClass.Message.BlockPresence.newBuilder()
+                        MessageOuterClass.Message.BlockPresence presence = MessageOuterClass.Message.BlockPresence
+                                .newBuilder()
                                 .setCid(ByteString.copyFrom(c.toBytes()))
                                 .setType(MessageOuterClass.Message.BlockPresenceType.DontHave)
                                 .build();
@@ -229,15 +237,14 @@ public class BitswapEngine {
         boolean receivedWantedBlock = false;
         for (MessageOuterClass.Message.Block block : msg.getPayloadList()) {
             byte[] cidPrefix = block.getPrefix().toByteArray();
-            Optional<String> auth = block.getAuth().isEmpty() ?
-                    Optional.empty() :
-                    Optional.of(ArrayOps.bytesToHex(block.getAuth().toByteArray()));
+            Optional<String> auth = block.getAuth().isEmpty() ? Optional.empty()
+                    : Optional.of(ArrayOps.bytesToHex(block.getAuth().toByteArray()));
             byte[] data = block.getData().toByteArray();
             ByteArrayInputStream bin = new ByteArrayInputStream(cidPrefix);
             try {
                 long version = Cid.readVarint(bin);
                 Cid.Codec codec = Cid.Codec.lookup(Cid.readVarint(bin));
-                Multihash.Type type = Multihash.Type.lookup((int)Cid.readVarint(bin));
+                Multihash.Type type = Multihash.Type.lookup((int) Cid.readVarint(bin));
                 if (type != Multihash.Type.sha2_256) {
                     LOG.info("Unsupported hash algorithm " + type.name());
                 } else {
@@ -260,14 +267,13 @@ public class BitswapEngine {
                 e.printStackTrace();
             }
         }
-        if (! localWants.isEmpty())
+        if (!localWants.isEmpty())
             System.out.println("Remaining: " + localWants.size());
         boolean receivedRequestedHave = false;
         for (MessageOuterClass.Message.BlockPresence blockPresence : msg.getBlockPresencesList()) {
             Cid c = Cid.cast(blockPresence.getCid().toByteArray());
-            Optional<String> auth = blockPresence.getAuth().isEmpty() ?
-                    Optional.empty() :
-                    Optional.of(ArrayOps.bytesToHex(blockPresence.getAuth().toByteArray()));
+            Optional<String> auth = blockPresence.getAuth().isEmpty() ? Optional.empty()
+                    : Optional.of(ArrayOps.bytesToHex(blockPresence.getAuth().toByteArray()));
             Want w = new Want(c, auth);
             boolean have = blockPresence.getType().getNumber() == 0;
             if (have && localWants.containsKey(w)) {
@@ -275,7 +281,7 @@ public class BitswapEngine {
                 blockHaves.put(w, source.remotePeerId());
             }
         }
-        if (absentBlocks > 10 && presentBlocks == 0 && ! receivedRequestedHave && ! receivedWantedBlock) {
+        if (absentBlocks > 10 && presentBlocks == 0 && !receivedRequestedHave && !receivedWantedBlock) {
             // This peer is sending us lots of irrelevant requests, block them
             blockedPeers.put(source.remotePeerId(), true);
             source.close();
@@ -285,20 +291,25 @@ public class BitswapEngine {
             return;
 
         buildAndSendMessages(Collections.emptyList(), presences, blocks, reply -> {
-            sentBytes.inc(reply.getSerializedSize());
+            // TODO(sonudoo): Propagating the context id in response shouldn't be required.
+            // But the current handler for the response on client side runs on a separate
+            // thread which doesn't inherit the trace context.
+            reply = reply.toBuilder().setTraceId(msg.getTraceId()).build();
+            sentBytes.inc(repdonely.getSerializedSize());
             source.writeAndFlush(reply);
+            // TODO(sonudoo): This logging should be performed by handler.
+            TraceLogger.getInstance().HandleBitswapServerEnd(reply, source.remotePeerId());
         });
-        System.out.println("Bitswap sent " + (presences.size() + blocks.size()) + " blocks in response.");
     }
 
     public void buildAndSendMessages(List<MessageOuterClass.Message.Wantlist.Entry> wants,
-                                     List<MessageOuterClass.Message.BlockPresence> presences,
-                                     List<MessageOuterClass.Message.Block> blocks,
-                                     Consumer<MessageOuterClass.Message> sender) {
+            List<MessageOuterClass.Message.BlockPresence> presences,
+            List<MessageOuterClass.Message.Block> blocks,
+            Consumer<MessageOuterClass.Message> sender) {
         // make sure we stay within the message size limit
         MessageOuterClass.Message.Builder builder = MessageOuterClass.Message.newBuilder();
         int messageSize = 0;
-        for (int i=0; i < wants.size(); i++) {
+        for (int i = 0; i < wants.size(); i++) {
             MessageOuterClass.Message.Wantlist.Entry want = wants.get(i);
             int wantSize = want.getSerializedSize();
             if (wantSize + messageSize > maxMessageSize) {
@@ -309,7 +320,7 @@ public class BitswapEngine {
             messageSize += wantSize;
             builder = builder.setWantlist(builder.getWantlist().toBuilder().addEntries(want).build());
         }
-        for (int i=0; i < presences.size(); i++) {
+        for (int i = 0; i < presences.size(); i++) {
             MessageOuterClass.Message.BlockPresence presence = presences.get(i);
             int presenceSize = presence.getSerializedSize();
             if (presenceSize + messageSize > maxMessageSize) {
@@ -320,7 +331,7 @@ public class BitswapEngine {
             messageSize += presenceSize;
             builder = builder.addBlockPresences(presence);
         }
-        for (int i=0; i < blocks.size(); i++) {
+        for (int i = 0; i < blocks.size(); i++) {
             MessageOuterClass.Message.Block block = blocks.get(i);
             int blockSize = block.getSerializedSize();
             if (blockSize + messageSize > maxMessageSize) {

--- a/src/main/java/org/peergos/protocol/bitswap/BitswapEngine.java
+++ b/src/main/java/org/peergos/protocol/bitswap/BitswapEngine.java
@@ -295,7 +295,7 @@ public class BitswapEngine {
             // But the current handler for the response on client side runs on a separate
             // thread which doesn't inherit the trace context.
             reply = reply.toBuilder().setTraceId(msg.getTraceId()).build();
-            sentBytes.inc(repdonely.getSerializedSize());
+            sentBytes.inc(reply.getSerializedSize());
             source.writeAndFlush(reply);
             // TODO(sonudoo): This logging should be performed by handler.
             TraceLogger.getInstance().HandleBitswapServerEnd(reply, source.remotePeerId());

--- a/src/main/java/org/peergos/protocol/bitswap/BitswapProtocol.java
+++ b/src/main/java/org/peergos/protocol/bitswap/BitswapProtocol.java
@@ -5,7 +5,7 @@ import io.libp2p.protocol.*;
 import io.prometheus.client.*;
 import org.jetbrains.annotations.*;
 import org.peergos.protocol.bitswap.pb.*;
-import org.peergos.util.*;
+import org.peergos.util.Logging;
 
 import java.util.concurrent.*;
 import java.util.logging.*;
@@ -52,7 +52,7 @@ public class BitswapProtocol extends ProtobufProtocolHandler<BitswapController> 
     @NotNull
     @Override
     protected CompletableFuture<BitswapController> onStartResponder(@NotNull Stream stream) {
-        if (! engine.allowConnection(stream.remotePeerId())) {
+        if (!engine.allowConnection(stream.remotePeerId())) {
             stream.close();
             blockedConnections.inc();
             return new CompletableFuture<>();

--- a/src/main/java/org/peergos/protocol/bitswap/pb/MessageOuterClass.java
+++ b/src/main/java/org/peergos/protocol/bitswap/pb/MessageOuterClass.java
@@ -15,7 +15,7 @@ public final class MessageOuterClass {
         (com.google.protobuf.ExtensionRegistryLite) registry);
   }
   public interface MessageOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:bitswap.message.pb.Message)
+      // @@protoc_insertion_point(interface_extends:org.peergos.protocol.bitswap.pb.Message)
       com.google.protobuf.MessageOrBuilder {
 
     /**
@@ -23,7 +23,8 @@ public final class MessageOuterClass {
      *[(gogoproto.nullable) = false];
      * </pre>
      *
-     * <code>.bitswap.message.pb.Message.Wantlist wantlist = 1;</code>
+     * <code>.org.peergos.protocol.bitswap.pb.Message.Wantlist wantlist = 1;</code>
+     * @return Whether the wantlist field is set.
      */
     boolean hasWantlist();
     /**
@@ -31,17 +32,18 @@ public final class MessageOuterClass {
      *[(gogoproto.nullable) = false];
      * </pre>
      *
-     * <code>.bitswap.message.pb.Message.Wantlist wantlist = 1;</code>
+     * <code>.org.peergos.protocol.bitswap.pb.Message.Wantlist wantlist = 1;</code>
+     * @return The wantlist.
      */
-    MessageOuterClass.Message.Wantlist getWantlist();
+    org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist getWantlist();
     /**
      * <pre>
      *[(gogoproto.nullable) = false];
      * </pre>
      *
-     * <code>.bitswap.message.pb.Message.Wantlist wantlist = 1;</code>
+     * <code>.org.peergos.protocol.bitswap.pb.Message.Wantlist wantlist = 1;</code>
      */
-    MessageOuterClass.Message.WantlistOrBuilder getWantlistOrBuilder();
+    org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.WantlistOrBuilder getWantlistOrBuilder();
 
     /**
      * <pre>
@@ -49,6 +51,7 @@ public final class MessageOuterClass {
      * </pre>
      *
      * <code>repeated bytes blocks = 2;</code>
+     * @return A list containing the blocks.
      */
     java.util.List<com.google.protobuf.ByteString> getBlocksList();
     /**
@@ -57,6 +60,7 @@ public final class MessageOuterClass {
      * </pre>
      *
      * <code>repeated bytes blocks = 2;</code>
+     * @return The count of blocks.
      */
     int getBlocksCount();
     /**
@@ -65,6 +69,8 @@ public final class MessageOuterClass {
      * </pre>
      *
      * <code>repeated bytes blocks = 2;</code>
+     * @param index The index of the element to return.
+     * @return The blocks at the given index.
      */
     com.google.protobuf.ByteString getBlocks(int index);
 
@@ -73,24 +79,24 @@ public final class MessageOuterClass {
      *[(gogoproto.nullable) = false];		// used to send Blocks in bitswap 1.1.0
      * </pre>
      *
-     * <code>repeated .bitswap.message.pb.Message.Block payload = 3;</code>
+     * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Block payload = 3;</code>
      */
-    java.util.List<MessageOuterClass.Message.Block>
+    java.util.List<org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block> 
         getPayloadList();
     /**
      * <pre>
      *[(gogoproto.nullable) = false];		// used to send Blocks in bitswap 1.1.0
      * </pre>
      *
-     * <code>repeated .bitswap.message.pb.Message.Block payload = 3;</code>
+     * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Block payload = 3;</code>
      */
-    MessageOuterClass.Message.Block getPayload(int index);
+    org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block getPayload(int index);
     /**
      * <pre>
      *[(gogoproto.nullable) = false];		// used to send Blocks in bitswap 1.1.0
      * </pre>
      *
-     * <code>repeated .bitswap.message.pb.Message.Block payload = 3;</code>
+     * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Block payload = 3;</code>
      */
     int getPayloadCount();
     /**
@@ -98,18 +104,18 @@ public final class MessageOuterClass {
      *[(gogoproto.nullable) = false];		// used to send Blocks in bitswap 1.1.0
      * </pre>
      *
-     * <code>repeated .bitswap.message.pb.Message.Block payload = 3;</code>
+     * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Block payload = 3;</code>
      */
-    java.util.List<? extends MessageOuterClass.Message.BlockOrBuilder>
+    java.util.List<? extends org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockOrBuilder> 
         getPayloadOrBuilderList();
     /**
      * <pre>
      *[(gogoproto.nullable) = false];		// used to send Blocks in bitswap 1.1.0
      * </pre>
      *
-     * <code>repeated .bitswap.message.pb.Message.Block payload = 3;</code>
+     * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Block payload = 3;</code>
      */
-    MessageOuterClass.Message.BlockOrBuilder getPayloadOrBuilder(
+    org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockOrBuilder getPayloadOrBuilder(
         int index);
 
     /**
@@ -117,24 +123,24 @@ public final class MessageOuterClass {
      *[(gogoproto.nullable) = false];
      * </pre>
      *
-     * <code>repeated .bitswap.message.pb.Message.BlockPresence blockPresences = 4;</code>
+     * <code>repeated .org.peergos.protocol.bitswap.pb.Message.BlockPresence blockPresences = 4;</code>
      */
-    java.util.List<MessageOuterClass.Message.BlockPresence>
+    java.util.List<org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence> 
         getBlockPresencesList();
     /**
      * <pre>
      *[(gogoproto.nullable) = false];
      * </pre>
      *
-     * <code>repeated .bitswap.message.pb.Message.BlockPresence blockPresences = 4;</code>
+     * <code>repeated .org.peergos.protocol.bitswap.pb.Message.BlockPresence blockPresences = 4;</code>
      */
-    MessageOuterClass.Message.BlockPresence getBlockPresences(int index);
+    org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence getBlockPresences(int index);
     /**
      * <pre>
      *[(gogoproto.nullable) = false];
      * </pre>
      *
-     * <code>repeated .bitswap.message.pb.Message.BlockPresence blockPresences = 4;</code>
+     * <code>repeated .org.peergos.protocol.bitswap.pb.Message.BlockPresence blockPresences = 4;</code>
      */
     int getBlockPresencesCount();
     /**
@@ -142,31 +148,44 @@ public final class MessageOuterClass {
      *[(gogoproto.nullable) = false];
      * </pre>
      *
-     * <code>repeated .bitswap.message.pb.Message.BlockPresence blockPresences = 4;</code>
+     * <code>repeated .org.peergos.protocol.bitswap.pb.Message.BlockPresence blockPresences = 4;</code>
      */
-    java.util.List<? extends MessageOuterClass.Message.BlockPresenceOrBuilder>
+    java.util.List<? extends org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresenceOrBuilder> 
         getBlockPresencesOrBuilderList();
     /**
      * <pre>
      *[(gogoproto.nullable) = false];
      * </pre>
      *
-     * <code>repeated .bitswap.message.pb.Message.BlockPresence blockPresences = 4;</code>
+     * <code>repeated .org.peergos.protocol.bitswap.pb.Message.BlockPresence blockPresences = 4;</code>
      */
-    MessageOuterClass.Message.BlockPresenceOrBuilder getBlockPresencesOrBuilder(
+    org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresenceOrBuilder getBlockPresencesOrBuilder(
         int index);
 
     /**
      * <code>int32 pendingBytes = 5;</code>
+     * @return The pendingBytes.
      */
     int getPendingBytes();
+
+    /**
+     * <code>string traceId = 6;</code>
+     * @return The traceId.
+     */
+    java.lang.String getTraceId();
+    /**
+     * <code>string traceId = 6;</code>
+     * @return The bytes for traceId.
+     */
+    com.google.protobuf.ByteString
+        getTraceIdBytes();
   }
   /**
-   * Protobuf type {@code bitswap.message.pb.Message}
+   * Protobuf type {@code org.peergos.protocol.bitswap.pb.Message}
    */
-  public  static final class Message extends
+  public static final class Message extends
       com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:bitswap.message.pb.Message)
+      // @@protoc_insertion_point(message_implements:org.peergos.protocol.bitswap.pb.Message)
       MessageOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use Message.newBuilder() to construct.
@@ -177,7 +196,14 @@ public final class MessageOuterClass {
       blocks_ = java.util.Collections.emptyList();
       payload_ = java.util.Collections.emptyList();
       blockPresences_ = java.util.Collections.emptyList();
-      pendingBytes_ = 0;
+      traceId_ = "";
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new Message();
     }
 
     @java.lang.Override
@@ -205,11 +231,11 @@ public final class MessageOuterClass {
               done = true;
               break;
             case 10: {
-              MessageOuterClass.Message.Wantlist.Builder subBuilder = null;
+              org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Builder subBuilder = null;
               if (wantlist_ != null) {
                 subBuilder = wantlist_.toBuilder();
               }
-              wantlist_ = input.readMessage(MessageOuterClass.Message.Wantlist.parser(), extensionRegistry);
+              wantlist_ = input.readMessage(org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(wantlist_);
                 wantlist_ = subBuilder.buildPartial();
@@ -218,29 +244,29 @@ public final class MessageOuterClass {
               break;
             }
             case 18: {
-              if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
                 blocks_ = new java.util.ArrayList<com.google.protobuf.ByteString>();
-                mutable_bitField0_ |= 0x00000002;
+                mutable_bitField0_ |= 0x00000001;
               }
               blocks_.add(input.readBytes());
               break;
             }
             case 26: {
-              if (!((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
-                payload_ = new java.util.ArrayList<MessageOuterClass.Message.Block>();
-                mutable_bitField0_ |= 0x00000004;
+              if (!((mutable_bitField0_ & 0x00000002) != 0)) {
+                payload_ = new java.util.ArrayList<org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block>();
+                mutable_bitField0_ |= 0x00000002;
               }
               payload_.add(
-                  input.readMessage(MessageOuterClass.Message.Block.parser(), extensionRegistry));
+                  input.readMessage(org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block.parser(), extensionRegistry));
               break;
             }
             case 34: {
-              if (!((mutable_bitField0_ & 0x00000008) == 0x00000008)) {
-                blockPresences_ = new java.util.ArrayList<MessageOuterClass.Message.BlockPresence>();
-                mutable_bitField0_ |= 0x00000008;
+              if (!((mutable_bitField0_ & 0x00000004) != 0)) {
+                blockPresences_ = new java.util.ArrayList<org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence>();
+                mutable_bitField0_ |= 0x00000004;
               }
               blockPresences_.add(
-                  input.readMessage(MessageOuterClass.Message.BlockPresence.parser(), extensionRegistry));
+                  input.readMessage(org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence.parser(), extensionRegistry));
               break;
             }
             case 40: {
@@ -248,8 +274,14 @@ public final class MessageOuterClass {
               pendingBytes_ = input.readInt32();
               break;
             }
+            case 50: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              traceId_ = s;
+              break;
+            }
             default: {
-              if (!parseUnknownFieldProto3(
+              if (!parseUnknownField(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
@@ -263,13 +295,13 @@ public final class MessageOuterClass {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
-          blocks_ = java.util.Collections.unmodifiableList(blocks_);
+        if (((mutable_bitField0_ & 0x00000001) != 0)) {
+          blocks_ = java.util.Collections.unmodifiableList(blocks_); // C
         }
-        if (((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((mutable_bitField0_ & 0x00000002) != 0)) {
           payload_ = java.util.Collections.unmodifiableList(payload_);
         }
-        if (((mutable_bitField0_ & 0x00000008) == 0x00000008)) {
+        if (((mutable_bitField0_ & 0x00000004) != 0)) {
           blockPresences_ = java.util.Collections.unmodifiableList(blockPresences_);
         }
         this.unknownFields = unknownFields.build();
@@ -278,19 +310,19 @@ public final class MessageOuterClass {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return MessageOuterClass.internal_static_bitswap_message_pb_Message_descriptor;
+      return org.peergos.protocol.bitswap.pb.MessageOuterClass.internal_static_bitswap_message_pb_Message_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return MessageOuterClass.internal_static_bitswap_message_pb_Message_fieldAccessorTable
+      return org.peergos.protocol.bitswap.pb.MessageOuterClass.internal_static_bitswap_message_pb_Message_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              MessageOuterClass.Message.class, MessageOuterClass.Message.Builder.class);
+              org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.class, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Builder.class);
     }
 
     /**
-     * Protobuf enum {@code bitswap.message.pb.Message.BlockPresenceType}
+     * Protobuf enum {@code org.peergos.protocol.bitswap.pb.Message.BlockPresenceType}
      */
     public enum BlockPresenceType
         implements com.google.protobuf.ProtocolMessageEnum {
@@ -324,6 +356,8 @@ public final class MessageOuterClass {
       }
 
       /**
+       * @param value The numeric wire value of the corresponding enum entry.
+       * @return The enum associated with the given numeric wire value.
        * @deprecated Use {@link #forNumber(int)} instead.
        */
       @java.lang.Deprecated
@@ -331,6 +365,10 @@ public final class MessageOuterClass {
         return forNumber(value);
       }
 
+      /**
+       * @param value The numeric wire value of the corresponding enum entry.
+       * @return The enum associated with the given numeric wire value.
+       */
       public static BlockPresenceType forNumber(int value) {
         switch (value) {
           case 0: return Have;
@@ -353,6 +391,10 @@ public final class MessageOuterClass {
 
       public final com.google.protobuf.Descriptors.EnumValueDescriptor
           getValueDescriptor() {
+        if (this == UNRECOGNIZED) {
+          throw new java.lang.IllegalStateException(
+              "Can't get the descriptor of an unrecognized enum value.");
+        }
         return getDescriptor().getValues().get(ordinal());
       }
       public final com.google.protobuf.Descriptors.EnumDescriptor
@@ -361,7 +403,7 @@ public final class MessageOuterClass {
       }
       public static final com.google.protobuf.Descriptors.EnumDescriptor
           getDescriptor() {
-        return MessageOuterClass.Message.getDescriptor().getEnumTypes().get(0);
+        return org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.getDescriptor().getEnumTypes().get(0);
       }
 
       private static final BlockPresenceType[] VALUES = values();
@@ -384,11 +426,11 @@ public final class MessageOuterClass {
         this.value = value;
       }
 
-      // @@protoc_insertion_point(enum_scope:bitswap.message.pb.Message.BlockPresenceType)
+      // @@protoc_insertion_point(enum_scope:org.peergos.protocol.bitswap.pb.Message.BlockPresenceType)
     }
 
     public interface WantlistOrBuilder extends
-        // @@protoc_insertion_point(interface_extends:bitswap.message.pb.Message.Wantlist)
+        // @@protoc_insertion_point(interface_extends:org.peergos.protocol.bitswap.pb.Message.Wantlist)
         com.google.protobuf.MessageOrBuilder {
 
       /**
@@ -396,24 +438,24 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];	// a list of wantlist entries
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.Wantlist.Entry entries = 1;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Wantlist.Entry entries = 1;</code>
        */
-      java.util.List<MessageOuterClass.Message.Wantlist.Entry>
+      java.util.List<org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry> 
           getEntriesList();
       /**
        * <pre>
        *[(gogoproto.nullable) = false];	// a list of wantlist entries
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.Wantlist.Entry entries = 1;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Wantlist.Entry entries = 1;</code>
        */
-      MessageOuterClass.Message.Wantlist.Entry getEntries(int index);
+      org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry getEntries(int index);
       /**
        * <pre>
        *[(gogoproto.nullable) = false];	// a list of wantlist entries
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.Wantlist.Entry entries = 1;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Wantlist.Entry entries = 1;</code>
        */
       int getEntriesCount();
       /**
@@ -421,18 +463,18 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];	// a list of wantlist entries
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.Wantlist.Entry entries = 1;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Wantlist.Entry entries = 1;</code>
        */
-      java.util.List<? extends MessageOuterClass.Message.Wantlist.EntryOrBuilder>
+      java.util.List<? extends org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.EntryOrBuilder> 
           getEntriesOrBuilderList();
       /**
        * <pre>
        *[(gogoproto.nullable) = false];	// a list of wantlist entries
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.Wantlist.Entry entries = 1;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Wantlist.Entry entries = 1;</code>
        */
-      MessageOuterClass.Message.Wantlist.EntryOrBuilder getEntriesOrBuilder(
+      org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.EntryOrBuilder getEntriesOrBuilder(
           int index);
 
       /**
@@ -441,15 +483,16 @@ public final class MessageOuterClass {
        * </pre>
        *
        * <code>bool full = 2;</code>
+       * @return The full.
        */
       boolean getFull();
     }
     /**
-     * Protobuf type {@code bitswap.message.pb.Message.Wantlist}
+     * Protobuf type {@code org.peergos.protocol.bitswap.pb.Message.Wantlist}
      */
-    public  static final class Wantlist extends
+    public static final class Wantlist extends
         com.google.protobuf.GeneratedMessageV3 implements
-        // @@protoc_insertion_point(message_implements:bitswap.message.pb.Message.Wantlist)
+        // @@protoc_insertion_point(message_implements:org.peergos.protocol.bitswap.pb.Message.Wantlist)
         WantlistOrBuilder {
     private static final long serialVersionUID = 0L;
       // Use Wantlist.newBuilder() to construct.
@@ -458,7 +501,13 @@ public final class MessageOuterClass {
       }
       private Wantlist() {
         entries_ = java.util.Collections.emptyList();
-        full_ = false;
+      }
+
+      @java.lang.Override
+      @SuppressWarnings({"unused"})
+      protected java.lang.Object newInstance(
+          UnusedPrivateParameter unused) {
+        return new Wantlist();
       }
 
       @java.lang.Override
@@ -486,12 +535,12 @@ public final class MessageOuterClass {
                 done = true;
                 break;
               case 10: {
-                if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-                  entries_ = new java.util.ArrayList<MessageOuterClass.Message.Wantlist.Entry>();
+                if (!((mutable_bitField0_ & 0x00000001) != 0)) {
+                  entries_ = new java.util.ArrayList<org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry>();
                   mutable_bitField0_ |= 0x00000001;
                 }
                 entries_.add(
-                    input.readMessage(MessageOuterClass.Message.Wantlist.Entry.parser(), extensionRegistry));
+                    input.readMessage(org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry.parser(), extensionRegistry));
                 break;
               }
               case 16: {
@@ -500,7 +549,7 @@ public final class MessageOuterClass {
                 break;
               }
               default: {
-                if (!parseUnknownFieldProto3(
+                if (!parseUnknownField(
                     input, unknownFields, extensionRegistry, tag)) {
                   done = true;
                 }
@@ -514,7 +563,7 @@ public final class MessageOuterClass {
           throw new com.google.protobuf.InvalidProtocolBufferException(
               e).setUnfinishedMessage(this);
         } finally {
-          if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+          if (((mutable_bitField0_ & 0x00000001) != 0)) {
             entries_ = java.util.Collections.unmodifiableList(entries_);
           }
           this.unknownFields = unknownFields.build();
@@ -523,19 +572,19 @@ public final class MessageOuterClass {
       }
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return MessageOuterClass.internal_static_bitswap_message_pb_Message_Wantlist_descriptor;
+        return org.peergos.protocol.bitswap.pb.MessageOuterClass.internal_static_bitswap_message_pb_Message_Wantlist_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return MessageOuterClass.internal_static_bitswap_message_pb_Message_Wantlist_fieldAccessorTable
+        return org.peergos.protocol.bitswap.pb.MessageOuterClass.internal_static_bitswap_message_pb_Message_Wantlist_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                MessageOuterClass.Message.Wantlist.class, MessageOuterClass.Message.Wantlist.Builder.class);
+                org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.class, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Builder.class);
       }
 
       /**
-       * Protobuf enum {@code bitswap.message.pb.Message.Wantlist.WantType}
+       * Protobuf enum {@code org.peergos.protocol.bitswap.pb.Message.Wantlist.WantType}
        */
       public enum WantType
           implements com.google.protobuf.ProtocolMessageEnum {
@@ -569,6 +618,8 @@ public final class MessageOuterClass {
         }
 
         /**
+         * @param value The numeric wire value of the corresponding enum entry.
+         * @return The enum associated with the given numeric wire value.
          * @deprecated Use {@link #forNumber(int)} instead.
          */
         @java.lang.Deprecated
@@ -576,6 +627,10 @@ public final class MessageOuterClass {
           return forNumber(value);
         }
 
+        /**
+         * @param value The numeric wire value of the corresponding enum entry.
+         * @return The enum associated with the given numeric wire value.
+         */
         public static WantType forNumber(int value) {
           switch (value) {
             case 0: return Block;
@@ -598,6 +653,10 @@ public final class MessageOuterClass {
 
         public final com.google.protobuf.Descriptors.EnumValueDescriptor
             getValueDescriptor() {
+          if (this == UNRECOGNIZED) {
+            throw new java.lang.IllegalStateException(
+                "Can't get the descriptor of an unrecognized enum value.");
+          }
           return getDescriptor().getValues().get(ordinal());
         }
         public final com.google.protobuf.Descriptors.EnumDescriptor
@@ -606,7 +665,7 @@ public final class MessageOuterClass {
         }
         public static final com.google.protobuf.Descriptors.EnumDescriptor
             getDescriptor() {
-          return MessageOuterClass.Message.Wantlist.getDescriptor().getEnumTypes().get(0);
+          return org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.getDescriptor().getEnumTypes().get(0);
         }
 
         private static final WantType[] VALUES = values();
@@ -629,11 +688,11 @@ public final class MessageOuterClass {
           this.value = value;
         }
 
-        // @@protoc_insertion_point(enum_scope:bitswap.message.pb.Message.Wantlist.WantType)
+        // @@protoc_insertion_point(enum_scope:org.peergos.protocol.bitswap.pb.Message.Wantlist.WantType)
       }
 
       public interface EntryOrBuilder extends
-          // @@protoc_insertion_point(interface_extends:bitswap.message.pb.Message.Wantlist.Entry)
+          // @@protoc_insertion_point(interface_extends:org.peergos.protocol.bitswap.pb.Message.Wantlist.Entry)
           com.google.protobuf.MessageOrBuilder {
 
         /**
@@ -642,6 +701,7 @@ public final class MessageOuterClass {
          * </pre>
          *
          * <code>bytes block = 1;</code>
+         * @return The block.
          */
         com.google.protobuf.ByteString getBlock();
 
@@ -651,6 +711,7 @@ public final class MessageOuterClass {
          * </pre>
          *
          * <code>int32 priority = 2;</code>
+         * @return The priority.
          */
         int getPriority();
 
@@ -660,6 +721,7 @@ public final class MessageOuterClass {
          * </pre>
          *
          * <code>bool cancel = 3;</code>
+         * @return The cancel.
          */
         boolean getCancel();
 
@@ -668,7 +730,8 @@ public final class MessageOuterClass {
          * Note: defaults to enum 0, ie Block
          * </pre>
          *
-         * <code>.bitswap.message.pb.Message.Wantlist.WantType wantType = 4;</code>
+         * <code>.org.peergos.protocol.bitswap.pb.Message.Wantlist.WantType wantType = 4;</code>
+         * @return The enum numeric value on the wire for wantType.
          */
         int getWantTypeValue();
         /**
@@ -676,9 +739,10 @@ public final class MessageOuterClass {
          * Note: defaults to enum 0, ie Block
          * </pre>
          *
-         * <code>.bitswap.message.pb.Message.Wantlist.WantType wantType = 4;</code>
+         * <code>.org.peergos.protocol.bitswap.pb.Message.Wantlist.WantType wantType = 4;</code>
+         * @return The wantType.
          */
-        MessageOuterClass.Message.Wantlist.WantType getWantType();
+        org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.WantType getWantType();
 
         /**
          * <pre>
@@ -686,20 +750,22 @@ public final class MessageOuterClass {
          * </pre>
          *
          * <code>bool sendDontHave = 5;</code>
+         * @return The sendDontHave.
          */
         boolean getSendDontHave();
 
         /**
          * <code>bytes auth = 6;</code>
+         * @return The auth.
          */
         com.google.protobuf.ByteString getAuth();
       }
       /**
-       * Protobuf type {@code bitswap.message.pb.Message.Wantlist.Entry}
+       * Protobuf type {@code org.peergos.protocol.bitswap.pb.Message.Wantlist.Entry}
        */
-      public  static final class Entry extends
+      public static final class Entry extends
           com.google.protobuf.GeneratedMessageV3 implements
-          // @@protoc_insertion_point(message_implements:bitswap.message.pb.Message.Wantlist.Entry)
+          // @@protoc_insertion_point(message_implements:org.peergos.protocol.bitswap.pb.Message.Wantlist.Entry)
           EntryOrBuilder {
       private static final long serialVersionUID = 0L;
         // Use Entry.newBuilder() to construct.
@@ -708,11 +774,15 @@ public final class MessageOuterClass {
         }
         private Entry() {
           block_ = com.google.protobuf.ByteString.EMPTY;
-          priority_ = 0;
-          cancel_ = false;
           wantType_ = 0;
-          sendDontHave_ = false;
           auth_ = com.google.protobuf.ByteString.EMPTY;
+        }
+
+        @java.lang.Override
+        @SuppressWarnings({"unused"})
+        protected java.lang.Object newInstance(
+            UnusedPrivateParameter unused) {
+          return new Entry();
         }
 
         @java.lang.Override
@@ -728,7 +798,6 @@ public final class MessageOuterClass {
           if (extensionRegistry == null) {
             throw new java.lang.NullPointerException();
           }
-          int mutable_bitField0_ = 0;
           com.google.protobuf.UnknownFieldSet.Builder unknownFields =
               com.google.protobuf.UnknownFieldSet.newBuilder();
           try {
@@ -771,7 +840,7 @@ public final class MessageOuterClass {
                   break;
                 }
                 default: {
-                  if (!parseUnknownFieldProto3(
+                  if (!parseUnknownField(
                       input, unknownFields, extensionRegistry, tag)) {
                     done = true;
                   }
@@ -791,15 +860,15 @@ public final class MessageOuterClass {
         }
         public static final com.google.protobuf.Descriptors.Descriptor
             getDescriptor() {
-          return MessageOuterClass.internal_static_bitswap_message_pb_Message_Wantlist_Entry_descriptor;
+          return org.peergos.protocol.bitswap.pb.MessageOuterClass.internal_static_bitswap_message_pb_Message_Wantlist_Entry_descriptor;
         }
 
         @java.lang.Override
         protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
             internalGetFieldAccessorTable() {
-          return MessageOuterClass.internal_static_bitswap_message_pb_Message_Wantlist_Entry_fieldAccessorTable
+          return org.peergos.protocol.bitswap.pb.MessageOuterClass.internal_static_bitswap_message_pb_Message_Wantlist_Entry_fieldAccessorTable
               .ensureFieldAccessorsInitialized(
-                  MessageOuterClass.Message.Wantlist.Entry.class, MessageOuterClass.Message.Wantlist.Entry.Builder.class);
+                  org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry.class, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry.Builder.class);
         }
 
         public static final int BLOCK_FIELD_NUMBER = 1;
@@ -810,7 +879,9 @@ public final class MessageOuterClass {
          * </pre>
          *
          * <code>bytes block = 1;</code>
+         * @return The block.
          */
+        @java.lang.Override
         public com.google.protobuf.ByteString getBlock() {
           return block_;
         }
@@ -823,7 +894,9 @@ public final class MessageOuterClass {
          * </pre>
          *
          * <code>int32 priority = 2;</code>
+         * @return The priority.
          */
+        @java.lang.Override
         public int getPriority() {
           return priority_;
         }
@@ -836,7 +909,9 @@ public final class MessageOuterClass {
          * </pre>
          *
          * <code>bool cancel = 3;</code>
+         * @return The cancel.
          */
+        @java.lang.Override
         public boolean getCancel() {
           return cancel_;
         }
@@ -848,9 +923,10 @@ public final class MessageOuterClass {
          * Note: defaults to enum 0, ie Block
          * </pre>
          *
-         * <code>.bitswap.message.pb.Message.Wantlist.WantType wantType = 4;</code>
+         * <code>.org.peergos.protocol.bitswap.pb.Message.Wantlist.WantType wantType = 4;</code>
+         * @return The enum numeric value on the wire for wantType.
          */
-        public int getWantTypeValue() {
+        @java.lang.Override public int getWantTypeValue() {
           return wantType_;
         }
         /**
@@ -858,12 +934,13 @@ public final class MessageOuterClass {
          * Note: defaults to enum 0, ie Block
          * </pre>
          *
-         * <code>.bitswap.message.pb.Message.Wantlist.WantType wantType = 4;</code>
+         * <code>.org.peergos.protocol.bitswap.pb.Message.Wantlist.WantType wantType = 4;</code>
+         * @return The wantType.
          */
-        public MessageOuterClass.Message.Wantlist.WantType getWantType() {
+        @java.lang.Override public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.WantType getWantType() {
           @SuppressWarnings("deprecation")
-          MessageOuterClass.Message.Wantlist.WantType result = MessageOuterClass.Message.Wantlist.WantType.valueOf(wantType_);
-          return result == null ? MessageOuterClass.Message.Wantlist.WantType.UNRECOGNIZED : result;
+          org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.WantType result = org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.WantType.valueOf(wantType_);
+          return result == null ? org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.WantType.UNRECOGNIZED : result;
         }
 
         public static final int SENDDONTHAVE_FIELD_NUMBER = 5;
@@ -874,7 +951,9 @@ public final class MessageOuterClass {
          * </pre>
          *
          * <code>bool sendDontHave = 5;</code>
+         * @return The sendDontHave.
          */
+        @java.lang.Override
         public boolean getSendDontHave() {
           return sendDontHave_;
         }
@@ -883,7 +962,9 @@ public final class MessageOuterClass {
         private com.google.protobuf.ByteString auth_;
         /**
          * <code>bytes auth = 6;</code>
+         * @return The auth.
          */
+        @java.lang.Override
         public com.google.protobuf.ByteString getAuth() {
           return auth_;
         }
@@ -911,7 +992,7 @@ public final class MessageOuterClass {
           if (cancel_ != false) {
             output.writeBool(3, cancel_);
           }
-          if (wantType_ != MessageOuterClass.Message.Wantlist.WantType.Block.getNumber()) {
+          if (wantType_ != org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.WantType.Block.getNumber()) {
             output.writeEnum(4, wantType_);
           }
           if (sendDontHave_ != false) {
@@ -941,7 +1022,7 @@ public final class MessageOuterClass {
             size += com.google.protobuf.CodedOutputStream
               .computeBoolSize(3, cancel_);
           }
-          if (wantType_ != MessageOuterClass.Message.Wantlist.WantType.Block.getNumber()) {
+          if (wantType_ != org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.WantType.Block.getNumber()) {
             size += com.google.protobuf.CodedOutputStream
               .computeEnumSize(4, wantType_);
           }
@@ -963,25 +1044,24 @@ public final class MessageOuterClass {
           if (obj == this) {
            return true;
           }
-          if (!(obj instanceof MessageOuterClass.Message.Wantlist.Entry)) {
+          if (!(obj instanceof org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry)) {
             return super.equals(obj);
           }
-          MessageOuterClass.Message.Wantlist.Entry other = (MessageOuterClass.Message.Wantlist.Entry) obj;
+          org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry other = (org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry) obj;
 
-          boolean result = true;
-          result = result && getBlock()
-              .equals(other.getBlock());
-          result = result && (getPriority()
-              == other.getPriority());
-          result = result && (getCancel()
-              == other.getCancel());
-          result = result && wantType_ == other.wantType_;
-          result = result && (getSendDontHave()
-              == other.getSendDontHave());
-          result = result && getAuth()
-              .equals(other.getAuth());
-          result = result && unknownFields.equals(other.unknownFields);
-          return result;
+          if (!getBlock()
+              .equals(other.getBlock())) return false;
+          if (getPriority()
+              != other.getPriority()) return false;
+          if (getCancel()
+              != other.getCancel()) return false;
+          if (wantType_ != other.wantType_) return false;
+          if (getSendDontHave()
+              != other.getSendDontHave()) return false;
+          if (!getAuth()
+              .equals(other.getAuth())) return false;
+          if (!unknownFields.equals(other.unknownFields)) return false;
+          return true;
         }
 
         @java.lang.Override
@@ -1010,69 +1090,69 @@ public final class MessageOuterClass {
           return hash;
         }
 
-        public static MessageOuterClass.Message.Wantlist.Entry parseFrom(
+        public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry parseFrom(
             java.nio.ByteBuffer data)
             throws com.google.protobuf.InvalidProtocolBufferException {
           return PARSER.parseFrom(data);
         }
-        public static MessageOuterClass.Message.Wantlist.Entry parseFrom(
+        public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry parseFrom(
             java.nio.ByteBuffer data,
             com.google.protobuf.ExtensionRegistryLite extensionRegistry)
             throws com.google.protobuf.InvalidProtocolBufferException {
           return PARSER.parseFrom(data, extensionRegistry);
         }
-        public static MessageOuterClass.Message.Wantlist.Entry parseFrom(
+        public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry parseFrom(
             com.google.protobuf.ByteString data)
             throws com.google.protobuf.InvalidProtocolBufferException {
           return PARSER.parseFrom(data);
         }
-        public static MessageOuterClass.Message.Wantlist.Entry parseFrom(
+        public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry parseFrom(
             com.google.protobuf.ByteString data,
             com.google.protobuf.ExtensionRegistryLite extensionRegistry)
             throws com.google.protobuf.InvalidProtocolBufferException {
           return PARSER.parseFrom(data, extensionRegistry);
         }
-        public static MessageOuterClass.Message.Wantlist.Entry parseFrom(byte[] data)
+        public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry parseFrom(byte[] data)
             throws com.google.protobuf.InvalidProtocolBufferException {
           return PARSER.parseFrom(data);
         }
-        public static MessageOuterClass.Message.Wantlist.Entry parseFrom(
+        public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry parseFrom(
             byte[] data,
             com.google.protobuf.ExtensionRegistryLite extensionRegistry)
             throws com.google.protobuf.InvalidProtocolBufferException {
           return PARSER.parseFrom(data, extensionRegistry);
         }
-        public static MessageOuterClass.Message.Wantlist.Entry parseFrom(java.io.InputStream input)
+        public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry parseFrom(java.io.InputStream input)
             throws java.io.IOException {
           return com.google.protobuf.GeneratedMessageV3
               .parseWithIOException(PARSER, input);
         }
-        public static MessageOuterClass.Message.Wantlist.Entry parseFrom(
+        public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry parseFrom(
             java.io.InputStream input,
             com.google.protobuf.ExtensionRegistryLite extensionRegistry)
             throws java.io.IOException {
           return com.google.protobuf.GeneratedMessageV3
               .parseWithIOException(PARSER, input, extensionRegistry);
         }
-        public static MessageOuterClass.Message.Wantlist.Entry parseDelimitedFrom(java.io.InputStream input)
+        public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry parseDelimitedFrom(java.io.InputStream input)
             throws java.io.IOException {
           return com.google.protobuf.GeneratedMessageV3
               .parseDelimitedWithIOException(PARSER, input);
         }
-        public static MessageOuterClass.Message.Wantlist.Entry parseDelimitedFrom(
+        public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry parseDelimitedFrom(
             java.io.InputStream input,
             com.google.protobuf.ExtensionRegistryLite extensionRegistry)
             throws java.io.IOException {
           return com.google.protobuf.GeneratedMessageV3
               .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
         }
-        public static MessageOuterClass.Message.Wantlist.Entry parseFrom(
+        public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry parseFrom(
             com.google.protobuf.CodedInputStream input)
             throws java.io.IOException {
           return com.google.protobuf.GeneratedMessageV3
               .parseWithIOException(PARSER, input);
         }
-        public static MessageOuterClass.Message.Wantlist.Entry parseFrom(
+        public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry parseFrom(
             com.google.protobuf.CodedInputStream input,
             com.google.protobuf.ExtensionRegistryLite extensionRegistry)
             throws java.io.IOException {
@@ -1085,7 +1165,7 @@ public final class MessageOuterClass {
         public static Builder newBuilder() {
           return DEFAULT_INSTANCE.toBuilder();
         }
-        public static Builder newBuilder(MessageOuterClass.Message.Wantlist.Entry prototype) {
+        public static Builder newBuilder(org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry prototype) {
           return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
         }
         @java.lang.Override
@@ -1101,26 +1181,26 @@ public final class MessageOuterClass {
           return builder;
         }
         /**
-         * Protobuf type {@code bitswap.message.pb.Message.Wantlist.Entry}
+         * Protobuf type {@code org.peergos.protocol.bitswap.pb.Message.Wantlist.Entry}
          */
         public static final class Builder extends
             com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-            // @@protoc_insertion_point(builder_implements:bitswap.message.pb.Message.Wantlist.Entry)
-            MessageOuterClass.Message.Wantlist.EntryOrBuilder {
+            // @@protoc_insertion_point(builder_implements:org.peergos.protocol.bitswap.pb.Message.Wantlist.Entry)
+            org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.EntryOrBuilder {
           public static final com.google.protobuf.Descriptors.Descriptor
               getDescriptor() {
-            return MessageOuterClass.internal_static_bitswap_message_pb_Message_Wantlist_Entry_descriptor;
+            return org.peergos.protocol.bitswap.pb.MessageOuterClass.internal_static_bitswap_message_pb_Message_Wantlist_Entry_descriptor;
           }
 
           @java.lang.Override
           protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
               internalGetFieldAccessorTable() {
-            return MessageOuterClass.internal_static_bitswap_message_pb_Message_Wantlist_Entry_fieldAccessorTable
+            return org.peergos.protocol.bitswap.pb.MessageOuterClass.internal_static_bitswap_message_pb_Message_Wantlist_Entry_fieldAccessorTable
                 .ensureFieldAccessorsInitialized(
-                    MessageOuterClass.Message.Wantlist.Entry.class, MessageOuterClass.Message.Wantlist.Entry.Builder.class);
+                    org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry.class, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry.Builder.class);
           }
 
-          // Construct using bitswap.message.pb.MessageOuterClass.Message.Wantlist.Entry.newBuilder()
+          // Construct using org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry.newBuilder()
           private Builder() {
             maybeForceBuilderInitialization();
           }
@@ -1156,17 +1236,17 @@ public final class MessageOuterClass {
           @java.lang.Override
           public com.google.protobuf.Descriptors.Descriptor
               getDescriptorForType() {
-            return MessageOuterClass.internal_static_bitswap_message_pb_Message_Wantlist_Entry_descriptor;
+            return org.peergos.protocol.bitswap.pb.MessageOuterClass.internal_static_bitswap_message_pb_Message_Wantlist_Entry_descriptor;
           }
 
           @java.lang.Override
-          public MessageOuterClass.Message.Wantlist.Entry getDefaultInstanceForType() {
-            return MessageOuterClass.Message.Wantlist.Entry.getDefaultInstance();
+          public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry getDefaultInstanceForType() {
+            return org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry.getDefaultInstance();
           }
 
           @java.lang.Override
-          public MessageOuterClass.Message.Wantlist.Entry build() {
-            MessageOuterClass.Message.Wantlist.Entry result = buildPartial();
+          public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry build() {
+            org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry result = buildPartial();
             if (!result.isInitialized()) {
               throw newUninitializedMessageException(result);
             }
@@ -1174,8 +1254,8 @@ public final class MessageOuterClass {
           }
 
           @java.lang.Override
-          public MessageOuterClass.Message.Wantlist.Entry buildPartial() {
-            MessageOuterClass.Message.Wantlist.Entry result = new MessageOuterClass.Message.Wantlist.Entry(this);
+          public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry buildPartial() {
+            org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry result = new org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry(this);
             result.block_ = block_;
             result.priority_ = priority_;
             result.cancel_ = cancel_;
@@ -1188,48 +1268,48 @@ public final class MessageOuterClass {
 
           @java.lang.Override
           public Builder clone() {
-            return (Builder) super.clone();
+            return super.clone();
           }
           @java.lang.Override
           public Builder setField(
               com.google.protobuf.Descriptors.FieldDescriptor field,
               java.lang.Object value) {
-            return (Builder) super.setField(field, value);
+            return super.setField(field, value);
           }
           @java.lang.Override
           public Builder clearField(
               com.google.protobuf.Descriptors.FieldDescriptor field) {
-            return (Builder) super.clearField(field);
+            return super.clearField(field);
           }
           @java.lang.Override
           public Builder clearOneof(
               com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-            return (Builder) super.clearOneof(oneof);
+            return super.clearOneof(oneof);
           }
           @java.lang.Override
           public Builder setRepeatedField(
               com.google.protobuf.Descriptors.FieldDescriptor field,
               int index, java.lang.Object value) {
-            return (Builder) super.setRepeatedField(field, index, value);
+            return super.setRepeatedField(field, index, value);
           }
           @java.lang.Override
           public Builder addRepeatedField(
               com.google.protobuf.Descriptors.FieldDescriptor field,
               java.lang.Object value) {
-            return (Builder) super.addRepeatedField(field, value);
+            return super.addRepeatedField(field, value);
           }
           @java.lang.Override
           public Builder mergeFrom(com.google.protobuf.Message other) {
-            if (other instanceof MessageOuterClass.Message.Wantlist.Entry) {
-              return mergeFrom((MessageOuterClass.Message.Wantlist.Entry)other);
+            if (other instanceof org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry) {
+              return mergeFrom((org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry)other);
             } else {
               super.mergeFrom(other);
               return this;
             }
           }
 
-          public Builder mergeFrom(MessageOuterClass.Message.Wantlist.Entry other) {
-            if (other == MessageOuterClass.Message.Wantlist.Entry.getDefaultInstance()) return this;
+          public Builder mergeFrom(org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry other) {
+            if (other == org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry.getDefaultInstance()) return this;
             if (other.getBlock() != com.google.protobuf.ByteString.EMPTY) {
               setBlock(other.getBlock());
             }
@@ -1263,11 +1343,11 @@ public final class MessageOuterClass {
               com.google.protobuf.CodedInputStream input,
               com.google.protobuf.ExtensionRegistryLite extensionRegistry)
               throws java.io.IOException {
-            MessageOuterClass.Message.Wantlist.Entry parsedMessage = null;
+            org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry parsedMessage = null;
             try {
               parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
             } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-              parsedMessage = (MessageOuterClass.Message.Wantlist.Entry) e.getUnfinishedMessage();
+              parsedMessage = (org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry) e.getUnfinishedMessage();
               throw e.unwrapIOException();
             } finally {
               if (parsedMessage != null) {
@@ -1284,7 +1364,9 @@ public final class MessageOuterClass {
            * </pre>
            *
            * <code>bytes block = 1;</code>
+           * @return The block.
            */
+          @java.lang.Override
           public com.google.protobuf.ByteString getBlock() {
             return block_;
           }
@@ -1294,6 +1376,8 @@ public final class MessageOuterClass {
            * </pre>
            *
            * <code>bytes block = 1;</code>
+           * @param value The block to set.
+           * @return This builder for chaining.
            */
           public Builder setBlock(com.google.protobuf.ByteString value) {
             if (value == null) {
@@ -1310,6 +1394,7 @@ public final class MessageOuterClass {
            * </pre>
            *
            * <code>bytes block = 1;</code>
+           * @return This builder for chaining.
            */
           public Builder clearBlock() {
             
@@ -1325,7 +1410,9 @@ public final class MessageOuterClass {
            * </pre>
            *
            * <code>int32 priority = 2;</code>
+           * @return The priority.
            */
+          @java.lang.Override
           public int getPriority() {
             return priority_;
           }
@@ -1335,6 +1422,8 @@ public final class MessageOuterClass {
            * </pre>
            *
            * <code>int32 priority = 2;</code>
+           * @param value The priority to set.
+           * @return This builder for chaining.
            */
           public Builder setPriority(int value) {
             
@@ -1348,6 +1437,7 @@ public final class MessageOuterClass {
            * </pre>
            *
            * <code>int32 priority = 2;</code>
+           * @return This builder for chaining.
            */
           public Builder clearPriority() {
             
@@ -1363,7 +1453,9 @@ public final class MessageOuterClass {
            * </pre>
            *
            * <code>bool cancel = 3;</code>
+           * @return The cancel.
            */
+          @java.lang.Override
           public boolean getCancel() {
             return cancel_;
           }
@@ -1373,6 +1465,8 @@ public final class MessageOuterClass {
            * </pre>
            *
            * <code>bool cancel = 3;</code>
+           * @param value The cancel to set.
+           * @return This builder for chaining.
            */
           public Builder setCancel(boolean value) {
             
@@ -1386,6 +1480,7 @@ public final class MessageOuterClass {
            * </pre>
            *
            * <code>bool cancel = 3;</code>
+           * @return This builder for chaining.
            */
           public Builder clearCancel() {
             
@@ -1400,9 +1495,10 @@ public final class MessageOuterClass {
            * Note: defaults to enum 0, ie Block
            * </pre>
            *
-           * <code>.bitswap.message.pb.Message.Wantlist.WantType wantType = 4;</code>
+           * <code>.org.peergos.protocol.bitswap.pb.Message.Wantlist.WantType wantType = 4;</code>
+           * @return The enum numeric value on the wire for wantType.
            */
-          public int getWantTypeValue() {
+          @java.lang.Override public int getWantTypeValue() {
             return wantType_;
           }
           /**
@@ -1410,9 +1506,12 @@ public final class MessageOuterClass {
            * Note: defaults to enum 0, ie Block
            * </pre>
            *
-           * <code>.bitswap.message.pb.Message.Wantlist.WantType wantType = 4;</code>
+           * <code>.org.peergos.protocol.bitswap.pb.Message.Wantlist.WantType wantType = 4;</code>
+           * @param value The enum numeric value on the wire for wantType to set.
+           * @return This builder for chaining.
            */
           public Builder setWantTypeValue(int value) {
+            
             wantType_ = value;
             onChanged();
             return this;
@@ -1422,21 +1521,25 @@ public final class MessageOuterClass {
            * Note: defaults to enum 0, ie Block
            * </pre>
            *
-           * <code>.bitswap.message.pb.Message.Wantlist.WantType wantType = 4;</code>
+           * <code>.org.peergos.protocol.bitswap.pb.Message.Wantlist.WantType wantType = 4;</code>
+           * @return The wantType.
            */
-          public MessageOuterClass.Message.Wantlist.WantType getWantType() {
+          @java.lang.Override
+          public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.WantType getWantType() {
             @SuppressWarnings("deprecation")
-            MessageOuterClass.Message.Wantlist.WantType result = MessageOuterClass.Message.Wantlist.WantType.valueOf(wantType_);
-            return result == null ? MessageOuterClass.Message.Wantlist.WantType.UNRECOGNIZED : result;
+            org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.WantType result = org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.WantType.valueOf(wantType_);
+            return result == null ? org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.WantType.UNRECOGNIZED : result;
           }
           /**
            * <pre>
            * Note: defaults to enum 0, ie Block
            * </pre>
            *
-           * <code>.bitswap.message.pb.Message.Wantlist.WantType wantType = 4;</code>
+           * <code>.org.peergos.protocol.bitswap.pb.Message.Wantlist.WantType wantType = 4;</code>
+           * @param value The wantType to set.
+           * @return This builder for chaining.
            */
-          public Builder setWantType(MessageOuterClass.Message.Wantlist.WantType value) {
+          public Builder setWantType(org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.WantType value) {
             if (value == null) {
               throw new NullPointerException();
             }
@@ -1450,7 +1553,8 @@ public final class MessageOuterClass {
            * Note: defaults to enum 0, ie Block
            * </pre>
            *
-           * <code>.bitswap.message.pb.Message.Wantlist.WantType wantType = 4;</code>
+           * <code>.org.peergos.protocol.bitswap.pb.Message.Wantlist.WantType wantType = 4;</code>
+           * @return This builder for chaining.
            */
           public Builder clearWantType() {
             
@@ -1466,7 +1570,9 @@ public final class MessageOuterClass {
            * </pre>
            *
            * <code>bool sendDontHave = 5;</code>
+           * @return The sendDontHave.
            */
+          @java.lang.Override
           public boolean getSendDontHave() {
             return sendDontHave_;
           }
@@ -1476,6 +1582,8 @@ public final class MessageOuterClass {
            * </pre>
            *
            * <code>bool sendDontHave = 5;</code>
+           * @param value The sendDontHave to set.
+           * @return This builder for chaining.
            */
           public Builder setSendDontHave(boolean value) {
             
@@ -1489,6 +1597,7 @@ public final class MessageOuterClass {
            * </pre>
            *
            * <code>bool sendDontHave = 5;</code>
+           * @return This builder for chaining.
            */
           public Builder clearSendDontHave() {
             
@@ -1500,12 +1609,16 @@ public final class MessageOuterClass {
           private com.google.protobuf.ByteString auth_ = com.google.protobuf.ByteString.EMPTY;
           /**
            * <code>bytes auth = 6;</code>
+           * @return The auth.
            */
+          @java.lang.Override
           public com.google.protobuf.ByteString getAuth() {
             return auth_;
           }
           /**
            * <code>bytes auth = 6;</code>
+           * @param value The auth to set.
+           * @return This builder for chaining.
            */
           public Builder setAuth(com.google.protobuf.ByteString value) {
             if (value == null) {
@@ -1518,6 +1631,7 @@ public final class MessageOuterClass {
           }
           /**
            * <code>bytes auth = 6;</code>
+           * @return This builder for chaining.
            */
           public Builder clearAuth() {
             
@@ -1528,7 +1642,7 @@ public final class MessageOuterClass {
           @java.lang.Override
           public final Builder setUnknownFields(
               final com.google.protobuf.UnknownFieldSet unknownFields) {
-            return super.setUnknownFieldsProto3(unknownFields);
+            return super.setUnknownFields(unknownFields);
           }
 
           @java.lang.Override
@@ -1538,16 +1652,16 @@ public final class MessageOuterClass {
           }
 
 
-          // @@protoc_insertion_point(builder_scope:bitswap.message.pb.Message.Wantlist.Entry)
+          // @@protoc_insertion_point(builder_scope:org.peergos.protocol.bitswap.pb.Message.Wantlist.Entry)
         }
 
-        // @@protoc_insertion_point(class_scope:bitswap.message.pb.Message.Wantlist.Entry)
-        private static final MessageOuterClass.Message.Wantlist.Entry DEFAULT_INSTANCE;
+        // @@protoc_insertion_point(class_scope:org.peergos.protocol.bitswap.pb.Message.Wantlist.Entry)
+        private static final org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry DEFAULT_INSTANCE;
         static {
-          DEFAULT_INSTANCE = new MessageOuterClass.Message.Wantlist.Entry();
+          DEFAULT_INSTANCE = new org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry();
         }
 
-        public static MessageOuterClass.Message.Wantlist.Entry getDefaultInstance() {
+        public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry getDefaultInstance() {
           return DEFAULT_INSTANCE;
         }
 
@@ -1572,23 +1686,23 @@ public final class MessageOuterClass {
         }
 
         @java.lang.Override
-        public MessageOuterClass.Message.Wantlist.Entry getDefaultInstanceForType() {
+        public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry getDefaultInstanceForType() {
           return DEFAULT_INSTANCE;
         }
 
       }
 
-      private int bitField0_;
       public static final int ENTRIES_FIELD_NUMBER = 1;
-      private java.util.List<MessageOuterClass.Message.Wantlist.Entry> entries_;
+      private java.util.List<org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry> entries_;
       /**
        * <pre>
        *[(gogoproto.nullable) = false];	// a list of wantlist entries
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.Wantlist.Entry entries = 1;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Wantlist.Entry entries = 1;</code>
        */
-      public java.util.List<MessageOuterClass.Message.Wantlist.Entry> getEntriesList() {
+      @java.lang.Override
+      public java.util.List<org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry> getEntriesList() {
         return entries_;
       }
       /**
@@ -1596,9 +1710,10 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];	// a list of wantlist entries
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.Wantlist.Entry entries = 1;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Wantlist.Entry entries = 1;</code>
        */
-      public java.util.List<? extends MessageOuterClass.Message.Wantlist.EntryOrBuilder>
+      @java.lang.Override
+      public java.util.List<? extends org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.EntryOrBuilder> 
           getEntriesOrBuilderList() {
         return entries_;
       }
@@ -1607,8 +1722,9 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];	// a list of wantlist entries
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.Wantlist.Entry entries = 1;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Wantlist.Entry entries = 1;</code>
        */
+      @java.lang.Override
       public int getEntriesCount() {
         return entries_.size();
       }
@@ -1617,9 +1733,10 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];	// a list of wantlist entries
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.Wantlist.Entry entries = 1;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Wantlist.Entry entries = 1;</code>
        */
-      public MessageOuterClass.Message.Wantlist.Entry getEntries(int index) {
+      @java.lang.Override
+      public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry getEntries(int index) {
         return entries_.get(index);
       }
       /**
@@ -1627,9 +1744,10 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];	// a list of wantlist entries
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.Wantlist.Entry entries = 1;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Wantlist.Entry entries = 1;</code>
        */
-      public MessageOuterClass.Message.Wantlist.EntryOrBuilder getEntriesOrBuilder(
+      @java.lang.Override
+      public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.EntryOrBuilder getEntriesOrBuilder(
           int index) {
         return entries_.get(index);
       }
@@ -1642,7 +1760,9 @@ public final class MessageOuterClass {
        * </pre>
        *
        * <code>bool full = 2;</code>
+       * @return The full.
        */
+      @java.lang.Override
       public boolean getFull() {
         return full_;
       }
@@ -1694,18 +1814,17 @@ public final class MessageOuterClass {
         if (obj == this) {
          return true;
         }
-        if (!(obj instanceof MessageOuterClass.Message.Wantlist)) {
+        if (!(obj instanceof org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist)) {
           return super.equals(obj);
         }
-        MessageOuterClass.Message.Wantlist other = (MessageOuterClass.Message.Wantlist) obj;
+        org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist other = (org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist) obj;
 
-        boolean result = true;
-        result = result && getEntriesList()
-            .equals(other.getEntriesList());
-        result = result && (getFull()
-            == other.getFull());
-        result = result && unknownFields.equals(other.unknownFields);
-        return result;
+        if (!getEntriesList()
+            .equals(other.getEntriesList())) return false;
+        if (getFull()
+            != other.getFull()) return false;
+        if (!unknownFields.equals(other.unknownFields)) return false;
+        return true;
       }
 
       @java.lang.Override
@@ -1727,69 +1846,69 @@ public final class MessageOuterClass {
         return hash;
       }
 
-      public static MessageOuterClass.Message.Wantlist parseFrom(
+      public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist parseFrom(
           java.nio.ByteBuffer data)
           throws com.google.protobuf.InvalidProtocolBufferException {
         return PARSER.parseFrom(data);
       }
-      public static MessageOuterClass.Message.Wantlist parseFrom(
+      public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist parseFrom(
           java.nio.ByteBuffer data,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
         return PARSER.parseFrom(data, extensionRegistry);
       }
-      public static MessageOuterClass.Message.Wantlist parseFrom(
+      public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist parseFrom(
           com.google.protobuf.ByteString data)
           throws com.google.protobuf.InvalidProtocolBufferException {
         return PARSER.parseFrom(data);
       }
-      public static MessageOuterClass.Message.Wantlist parseFrom(
+      public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist parseFrom(
           com.google.protobuf.ByteString data,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
         return PARSER.parseFrom(data, extensionRegistry);
       }
-      public static MessageOuterClass.Message.Wantlist parseFrom(byte[] data)
+      public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist parseFrom(byte[] data)
           throws com.google.protobuf.InvalidProtocolBufferException {
         return PARSER.parseFrom(data);
       }
-      public static MessageOuterClass.Message.Wantlist parseFrom(
+      public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist parseFrom(
           byte[] data,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
         return PARSER.parseFrom(data, extensionRegistry);
       }
-      public static MessageOuterClass.Message.Wantlist parseFrom(java.io.InputStream input)
+      public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist parseFrom(java.io.InputStream input)
           throws java.io.IOException {
         return com.google.protobuf.GeneratedMessageV3
             .parseWithIOException(PARSER, input);
       }
-      public static MessageOuterClass.Message.Wantlist parseFrom(
+      public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist parseFrom(
           java.io.InputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
         return com.google.protobuf.GeneratedMessageV3
             .parseWithIOException(PARSER, input, extensionRegistry);
       }
-      public static MessageOuterClass.Message.Wantlist parseDelimitedFrom(java.io.InputStream input)
+      public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist parseDelimitedFrom(java.io.InputStream input)
           throws java.io.IOException {
         return com.google.protobuf.GeneratedMessageV3
             .parseDelimitedWithIOException(PARSER, input);
       }
-      public static MessageOuterClass.Message.Wantlist parseDelimitedFrom(
+      public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist parseDelimitedFrom(
           java.io.InputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
         return com.google.protobuf.GeneratedMessageV3
             .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
       }
-      public static MessageOuterClass.Message.Wantlist parseFrom(
+      public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist parseFrom(
           com.google.protobuf.CodedInputStream input)
           throws java.io.IOException {
         return com.google.protobuf.GeneratedMessageV3
             .parseWithIOException(PARSER, input);
       }
-      public static MessageOuterClass.Message.Wantlist parseFrom(
+      public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist parseFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
@@ -1802,7 +1921,7 @@ public final class MessageOuterClass {
       public static Builder newBuilder() {
         return DEFAULT_INSTANCE.toBuilder();
       }
-      public static Builder newBuilder(MessageOuterClass.Message.Wantlist prototype) {
+      public static Builder newBuilder(org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist prototype) {
         return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
       }
       @java.lang.Override
@@ -1818,26 +1937,26 @@ public final class MessageOuterClass {
         return builder;
       }
       /**
-       * Protobuf type {@code bitswap.message.pb.Message.Wantlist}
+       * Protobuf type {@code org.peergos.protocol.bitswap.pb.Message.Wantlist}
        */
       public static final class Builder extends
           com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-          // @@protoc_insertion_point(builder_implements:bitswap.message.pb.Message.Wantlist)
-          MessageOuterClass.Message.WantlistOrBuilder {
+          // @@protoc_insertion_point(builder_implements:org.peergos.protocol.bitswap.pb.Message.Wantlist)
+          org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.WantlistOrBuilder {
         public static final com.google.protobuf.Descriptors.Descriptor
             getDescriptor() {
-          return MessageOuterClass.internal_static_bitswap_message_pb_Message_Wantlist_descriptor;
+          return org.peergos.protocol.bitswap.pb.MessageOuterClass.internal_static_bitswap_message_pb_Message_Wantlist_descriptor;
         }
 
         @java.lang.Override
         protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
             internalGetFieldAccessorTable() {
-          return MessageOuterClass.internal_static_bitswap_message_pb_Message_Wantlist_fieldAccessorTable
+          return org.peergos.protocol.bitswap.pb.MessageOuterClass.internal_static_bitswap_message_pb_Message_Wantlist_fieldAccessorTable
               .ensureFieldAccessorsInitialized(
-                  MessageOuterClass.Message.Wantlist.class, MessageOuterClass.Message.Wantlist.Builder.class);
+                  org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.class, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Builder.class);
         }
 
-        // Construct using bitswap.message.pb.MessageOuterClass.Message.Wantlist.newBuilder()
+        // Construct using org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.newBuilder()
         private Builder() {
           maybeForceBuilderInitialization();
         }
@@ -1870,17 +1989,17 @@ public final class MessageOuterClass {
         @java.lang.Override
         public com.google.protobuf.Descriptors.Descriptor
             getDescriptorForType() {
-          return MessageOuterClass.internal_static_bitswap_message_pb_Message_Wantlist_descriptor;
+          return org.peergos.protocol.bitswap.pb.MessageOuterClass.internal_static_bitswap_message_pb_Message_Wantlist_descriptor;
         }
 
         @java.lang.Override
-        public MessageOuterClass.Message.Wantlist getDefaultInstanceForType() {
-          return MessageOuterClass.Message.Wantlist.getDefaultInstance();
+        public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist getDefaultInstanceForType() {
+          return org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.getDefaultInstance();
         }
 
         @java.lang.Override
-        public MessageOuterClass.Message.Wantlist build() {
-          MessageOuterClass.Message.Wantlist result = buildPartial();
+        public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist build() {
+          org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist result = buildPartial();
           if (!result.isInitialized()) {
             throw newUninitializedMessageException(result);
           }
@@ -1888,12 +2007,11 @@ public final class MessageOuterClass {
         }
 
         @java.lang.Override
-        public MessageOuterClass.Message.Wantlist buildPartial() {
-          MessageOuterClass.Message.Wantlist result = new MessageOuterClass.Message.Wantlist(this);
+        public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist buildPartial() {
+          org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist result = new org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist(this);
           int from_bitField0_ = bitField0_;
-          int to_bitField0_ = 0;
           if (entriesBuilder_ == null) {
-            if (((bitField0_ & 0x00000001) == 0x00000001)) {
+            if (((bitField0_ & 0x00000001) != 0)) {
               entries_ = java.util.Collections.unmodifiableList(entries_);
               bitField0_ = (bitField0_ & ~0x00000001);
             }
@@ -1902,55 +2020,54 @@ public final class MessageOuterClass {
             result.entries_ = entriesBuilder_.build();
           }
           result.full_ = full_;
-          result.bitField0_ = to_bitField0_;
           onBuilt();
           return result;
         }
 
         @java.lang.Override
         public Builder clone() {
-          return (Builder) super.clone();
+          return super.clone();
         }
         @java.lang.Override
         public Builder setField(
             com.google.protobuf.Descriptors.FieldDescriptor field,
             java.lang.Object value) {
-          return (Builder) super.setField(field, value);
+          return super.setField(field, value);
         }
         @java.lang.Override
         public Builder clearField(
             com.google.protobuf.Descriptors.FieldDescriptor field) {
-          return (Builder) super.clearField(field);
+          return super.clearField(field);
         }
         @java.lang.Override
         public Builder clearOneof(
             com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-          return (Builder) super.clearOneof(oneof);
+          return super.clearOneof(oneof);
         }
         @java.lang.Override
         public Builder setRepeatedField(
             com.google.protobuf.Descriptors.FieldDescriptor field,
             int index, java.lang.Object value) {
-          return (Builder) super.setRepeatedField(field, index, value);
+          return super.setRepeatedField(field, index, value);
         }
         @java.lang.Override
         public Builder addRepeatedField(
             com.google.protobuf.Descriptors.FieldDescriptor field,
             java.lang.Object value) {
-          return (Builder) super.addRepeatedField(field, value);
+          return super.addRepeatedField(field, value);
         }
         @java.lang.Override
         public Builder mergeFrom(com.google.protobuf.Message other) {
-          if (other instanceof MessageOuterClass.Message.Wantlist) {
-            return mergeFrom((MessageOuterClass.Message.Wantlist)other);
+          if (other instanceof org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist) {
+            return mergeFrom((org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist)other);
           } else {
             super.mergeFrom(other);
             return this;
           }
         }
 
-        public Builder mergeFrom(MessageOuterClass.Message.Wantlist other) {
-          if (other == MessageOuterClass.Message.Wantlist.getDefaultInstance()) return this;
+        public Builder mergeFrom(org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist other) {
+          if (other == org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.getDefaultInstance()) return this;
           if (entriesBuilder_ == null) {
             if (!other.entries_.isEmpty()) {
               if (entries_.isEmpty()) {
@@ -1995,11 +2112,11 @@ public final class MessageOuterClass {
             com.google.protobuf.CodedInputStream input,
             com.google.protobuf.ExtensionRegistryLite extensionRegistry)
             throws java.io.IOException {
-          MessageOuterClass.Message.Wantlist parsedMessage = null;
+          org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist parsedMessage = null;
           try {
             parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
           } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-            parsedMessage = (MessageOuterClass.Message.Wantlist) e.getUnfinishedMessage();
+            parsedMessage = (org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist) e.getUnfinishedMessage();
             throw e.unwrapIOException();
           } finally {
             if (parsedMessage != null) {
@@ -2010,26 +2127,26 @@ public final class MessageOuterClass {
         }
         private int bitField0_;
 
-        private java.util.List<MessageOuterClass.Message.Wantlist.Entry> entries_ =
+        private java.util.List<org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry> entries_ =
           java.util.Collections.emptyList();
         private void ensureEntriesIsMutable() {
-          if (!((bitField0_ & 0x00000001) == 0x00000001)) {
-            entries_ = new java.util.ArrayList<MessageOuterClass.Message.Wantlist.Entry>(entries_);
+          if (!((bitField0_ & 0x00000001) != 0)) {
+            entries_ = new java.util.ArrayList<org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry>(entries_);
             bitField0_ |= 0x00000001;
            }
         }
 
         private com.google.protobuf.RepeatedFieldBuilderV3<
-            MessageOuterClass.Message.Wantlist.Entry, MessageOuterClass.Message.Wantlist.Entry.Builder, MessageOuterClass.Message.Wantlist.EntryOrBuilder> entriesBuilder_;
+            org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry.Builder, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.EntryOrBuilder> entriesBuilder_;
 
         /**
          * <pre>
          *[(gogoproto.nullable) = false];	// a list of wantlist entries
          * </pre>
          *
-         * <code>repeated .bitswap.message.pb.Message.Wantlist.Entry entries = 1;</code>
+         * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Wantlist.Entry entries = 1;</code>
          */
-        public java.util.List<MessageOuterClass.Message.Wantlist.Entry> getEntriesList() {
+        public java.util.List<org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry> getEntriesList() {
           if (entriesBuilder_ == null) {
             return java.util.Collections.unmodifiableList(entries_);
           } else {
@@ -2041,7 +2158,7 @@ public final class MessageOuterClass {
          *[(gogoproto.nullable) = false];	// a list of wantlist entries
          * </pre>
          *
-         * <code>repeated .bitswap.message.pb.Message.Wantlist.Entry entries = 1;</code>
+         * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Wantlist.Entry entries = 1;</code>
          */
         public int getEntriesCount() {
           if (entriesBuilder_ == null) {
@@ -2055,9 +2172,9 @@ public final class MessageOuterClass {
          *[(gogoproto.nullable) = false];	// a list of wantlist entries
          * </pre>
          *
-         * <code>repeated .bitswap.message.pb.Message.Wantlist.Entry entries = 1;</code>
+         * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Wantlist.Entry entries = 1;</code>
          */
-        public MessageOuterClass.Message.Wantlist.Entry getEntries(int index) {
+        public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry getEntries(int index) {
           if (entriesBuilder_ == null) {
             return entries_.get(index);
           } else {
@@ -2069,10 +2186,10 @@ public final class MessageOuterClass {
          *[(gogoproto.nullable) = false];	// a list of wantlist entries
          * </pre>
          *
-         * <code>repeated .bitswap.message.pb.Message.Wantlist.Entry entries = 1;</code>
+         * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Wantlist.Entry entries = 1;</code>
          */
         public Builder setEntries(
-            int index, MessageOuterClass.Message.Wantlist.Entry value) {
+            int index, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry value) {
           if (entriesBuilder_ == null) {
             if (value == null) {
               throw new NullPointerException();
@@ -2090,10 +2207,10 @@ public final class MessageOuterClass {
          *[(gogoproto.nullable) = false];	// a list of wantlist entries
          * </pre>
          *
-         * <code>repeated .bitswap.message.pb.Message.Wantlist.Entry entries = 1;</code>
+         * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Wantlist.Entry entries = 1;</code>
          */
         public Builder setEntries(
-            int index, MessageOuterClass.Message.Wantlist.Entry.Builder builderForValue) {
+            int index, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry.Builder builderForValue) {
           if (entriesBuilder_ == null) {
             ensureEntriesIsMutable();
             entries_.set(index, builderForValue.build());
@@ -2108,9 +2225,9 @@ public final class MessageOuterClass {
          *[(gogoproto.nullable) = false];	// a list of wantlist entries
          * </pre>
          *
-         * <code>repeated .bitswap.message.pb.Message.Wantlist.Entry entries = 1;</code>
+         * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Wantlist.Entry entries = 1;</code>
          */
-        public Builder addEntries(MessageOuterClass.Message.Wantlist.Entry value) {
+        public Builder addEntries(org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry value) {
           if (entriesBuilder_ == null) {
             if (value == null) {
               throw new NullPointerException();
@@ -2128,10 +2245,10 @@ public final class MessageOuterClass {
          *[(gogoproto.nullable) = false];	// a list of wantlist entries
          * </pre>
          *
-         * <code>repeated .bitswap.message.pb.Message.Wantlist.Entry entries = 1;</code>
+         * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Wantlist.Entry entries = 1;</code>
          */
         public Builder addEntries(
-            int index, MessageOuterClass.Message.Wantlist.Entry value) {
+            int index, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry value) {
           if (entriesBuilder_ == null) {
             if (value == null) {
               throw new NullPointerException();
@@ -2149,10 +2266,10 @@ public final class MessageOuterClass {
          *[(gogoproto.nullable) = false];	// a list of wantlist entries
          * </pre>
          *
-         * <code>repeated .bitswap.message.pb.Message.Wantlist.Entry entries = 1;</code>
+         * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Wantlist.Entry entries = 1;</code>
          */
         public Builder addEntries(
-            MessageOuterClass.Message.Wantlist.Entry.Builder builderForValue) {
+            org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry.Builder builderForValue) {
           if (entriesBuilder_ == null) {
             ensureEntriesIsMutable();
             entries_.add(builderForValue.build());
@@ -2167,10 +2284,10 @@ public final class MessageOuterClass {
          *[(gogoproto.nullable) = false];	// a list of wantlist entries
          * </pre>
          *
-         * <code>repeated .bitswap.message.pb.Message.Wantlist.Entry entries = 1;</code>
+         * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Wantlist.Entry entries = 1;</code>
          */
         public Builder addEntries(
-            int index, MessageOuterClass.Message.Wantlist.Entry.Builder builderForValue) {
+            int index, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry.Builder builderForValue) {
           if (entriesBuilder_ == null) {
             ensureEntriesIsMutable();
             entries_.add(index, builderForValue.build());
@@ -2185,10 +2302,10 @@ public final class MessageOuterClass {
          *[(gogoproto.nullable) = false];	// a list of wantlist entries
          * </pre>
          *
-         * <code>repeated .bitswap.message.pb.Message.Wantlist.Entry entries = 1;</code>
+         * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Wantlist.Entry entries = 1;</code>
          */
         public Builder addAllEntries(
-            java.lang.Iterable<? extends MessageOuterClass.Message.Wantlist.Entry> values) {
+            java.lang.Iterable<? extends org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry> values) {
           if (entriesBuilder_ == null) {
             ensureEntriesIsMutable();
             com.google.protobuf.AbstractMessageLite.Builder.addAll(
@@ -2204,7 +2321,7 @@ public final class MessageOuterClass {
          *[(gogoproto.nullable) = false];	// a list of wantlist entries
          * </pre>
          *
-         * <code>repeated .bitswap.message.pb.Message.Wantlist.Entry entries = 1;</code>
+         * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Wantlist.Entry entries = 1;</code>
          */
         public Builder clearEntries() {
           if (entriesBuilder_ == null) {
@@ -2221,7 +2338,7 @@ public final class MessageOuterClass {
          *[(gogoproto.nullable) = false];	// a list of wantlist entries
          * </pre>
          *
-         * <code>repeated .bitswap.message.pb.Message.Wantlist.Entry entries = 1;</code>
+         * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Wantlist.Entry entries = 1;</code>
          */
         public Builder removeEntries(int index) {
           if (entriesBuilder_ == null) {
@@ -2238,9 +2355,9 @@ public final class MessageOuterClass {
          *[(gogoproto.nullable) = false];	// a list of wantlist entries
          * </pre>
          *
-         * <code>repeated .bitswap.message.pb.Message.Wantlist.Entry entries = 1;</code>
+         * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Wantlist.Entry entries = 1;</code>
          */
-        public MessageOuterClass.Message.Wantlist.Entry.Builder getEntriesBuilder(
+        public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry.Builder getEntriesBuilder(
             int index) {
           return getEntriesFieldBuilder().getBuilder(index);
         }
@@ -2249,9 +2366,9 @@ public final class MessageOuterClass {
          *[(gogoproto.nullable) = false];	// a list of wantlist entries
          * </pre>
          *
-         * <code>repeated .bitswap.message.pb.Message.Wantlist.Entry entries = 1;</code>
+         * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Wantlist.Entry entries = 1;</code>
          */
-        public MessageOuterClass.Message.Wantlist.EntryOrBuilder getEntriesOrBuilder(
+        public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.EntryOrBuilder getEntriesOrBuilder(
             int index) {
           if (entriesBuilder_ == null) {
             return entries_.get(index);  } else {
@@ -2263,9 +2380,9 @@ public final class MessageOuterClass {
          *[(gogoproto.nullable) = false];	// a list of wantlist entries
          * </pre>
          *
-         * <code>repeated .bitswap.message.pb.Message.Wantlist.Entry entries = 1;</code>
+         * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Wantlist.Entry entries = 1;</code>
          */
-        public java.util.List<? extends MessageOuterClass.Message.Wantlist.EntryOrBuilder>
+        public java.util.List<? extends org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.EntryOrBuilder> 
              getEntriesOrBuilderList() {
           if (entriesBuilder_ != null) {
             return entriesBuilder_.getMessageOrBuilderList();
@@ -2278,43 +2395,43 @@ public final class MessageOuterClass {
          *[(gogoproto.nullable) = false];	// a list of wantlist entries
          * </pre>
          *
-         * <code>repeated .bitswap.message.pb.Message.Wantlist.Entry entries = 1;</code>
+         * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Wantlist.Entry entries = 1;</code>
          */
-        public MessageOuterClass.Message.Wantlist.Entry.Builder addEntriesBuilder() {
+        public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry.Builder addEntriesBuilder() {
           return getEntriesFieldBuilder().addBuilder(
-              MessageOuterClass.Message.Wantlist.Entry.getDefaultInstance());
+              org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry.getDefaultInstance());
         }
         /**
          * <pre>
          *[(gogoproto.nullable) = false];	// a list of wantlist entries
          * </pre>
          *
-         * <code>repeated .bitswap.message.pb.Message.Wantlist.Entry entries = 1;</code>
+         * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Wantlist.Entry entries = 1;</code>
          */
-        public MessageOuterClass.Message.Wantlist.Entry.Builder addEntriesBuilder(
+        public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry.Builder addEntriesBuilder(
             int index) {
           return getEntriesFieldBuilder().addBuilder(
-              index, MessageOuterClass.Message.Wantlist.Entry.getDefaultInstance());
+              index, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry.getDefaultInstance());
         }
         /**
          * <pre>
          *[(gogoproto.nullable) = false];	// a list of wantlist entries
          * </pre>
          *
-         * <code>repeated .bitswap.message.pb.Message.Wantlist.Entry entries = 1;</code>
+         * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Wantlist.Entry entries = 1;</code>
          */
-        public java.util.List<MessageOuterClass.Message.Wantlist.Entry.Builder>
+        public java.util.List<org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry.Builder> 
              getEntriesBuilderList() {
           return getEntriesFieldBuilder().getBuilderList();
         }
         private com.google.protobuf.RepeatedFieldBuilderV3<
-            MessageOuterClass.Message.Wantlist.Entry, MessageOuterClass.Message.Wantlist.Entry.Builder, MessageOuterClass.Message.Wantlist.EntryOrBuilder>
+            org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry.Builder, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.EntryOrBuilder> 
             getEntriesFieldBuilder() {
           if (entriesBuilder_ == null) {
             entriesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-                MessageOuterClass.Message.Wantlist.Entry, MessageOuterClass.Message.Wantlist.Entry.Builder, MessageOuterClass.Message.Wantlist.EntryOrBuilder>(
+                org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Entry.Builder, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.EntryOrBuilder>(
                     entries_,
-                    ((bitField0_ & 0x00000001) == 0x00000001),
+                    ((bitField0_ & 0x00000001) != 0),
                     getParentForChildren(),
                     isClean());
             entries_ = null;
@@ -2329,7 +2446,9 @@ public final class MessageOuterClass {
          * </pre>
          *
          * <code>bool full = 2;</code>
+         * @return The full.
          */
+        @java.lang.Override
         public boolean getFull() {
           return full_;
         }
@@ -2339,6 +2458,8 @@ public final class MessageOuterClass {
          * </pre>
          *
          * <code>bool full = 2;</code>
+         * @param value The full to set.
+         * @return This builder for chaining.
          */
         public Builder setFull(boolean value) {
           
@@ -2352,6 +2473,7 @@ public final class MessageOuterClass {
          * </pre>
          *
          * <code>bool full = 2;</code>
+         * @return This builder for chaining.
          */
         public Builder clearFull() {
           
@@ -2362,7 +2484,7 @@ public final class MessageOuterClass {
         @java.lang.Override
         public final Builder setUnknownFields(
             final com.google.protobuf.UnknownFieldSet unknownFields) {
-          return super.setUnknownFieldsProto3(unknownFields);
+          return super.setUnknownFields(unknownFields);
         }
 
         @java.lang.Override
@@ -2372,16 +2494,16 @@ public final class MessageOuterClass {
         }
 
 
-        // @@protoc_insertion_point(builder_scope:bitswap.message.pb.Message.Wantlist)
+        // @@protoc_insertion_point(builder_scope:org.peergos.protocol.bitswap.pb.Message.Wantlist)
       }
 
-      // @@protoc_insertion_point(class_scope:bitswap.message.pb.Message.Wantlist)
-      private static final MessageOuterClass.Message.Wantlist DEFAULT_INSTANCE;
+      // @@protoc_insertion_point(class_scope:org.peergos.protocol.bitswap.pb.Message.Wantlist)
+      private static final org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist DEFAULT_INSTANCE;
       static {
-        DEFAULT_INSTANCE = new MessageOuterClass.Message.Wantlist();
+        DEFAULT_INSTANCE = new org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist();
       }
 
-      public static MessageOuterClass.Message.Wantlist getDefaultInstance() {
+      public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist getDefaultInstance() {
         return DEFAULT_INSTANCE;
       }
 
@@ -2406,14 +2528,14 @@ public final class MessageOuterClass {
       }
 
       @java.lang.Override
-      public MessageOuterClass.Message.Wantlist getDefaultInstanceForType() {
+      public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist getDefaultInstanceForType() {
         return DEFAULT_INSTANCE;
       }
 
     }
 
     public interface BlockOrBuilder extends
-        // @@protoc_insertion_point(interface_extends:bitswap.message.pb.Message.Block)
+        // @@protoc_insertion_point(interface_extends:org.peergos.protocol.bitswap.pb.Message.Block)
         com.google.protobuf.MessageOrBuilder {
 
       /**
@@ -2422,25 +2544,28 @@ public final class MessageOuterClass {
        * </pre>
        *
        * <code>bytes prefix = 1;</code>
+       * @return The prefix.
        */
       com.google.protobuf.ByteString getPrefix();
 
       /**
        * <code>bytes data = 2;</code>
+       * @return The data.
        */
       com.google.protobuf.ByteString getData();
 
       /**
        * <code>bytes auth = 3;</code>
+       * @return The auth.
        */
       com.google.protobuf.ByteString getAuth();
     }
     /**
-     * Protobuf type {@code bitswap.message.pb.Message.Block}
+     * Protobuf type {@code org.peergos.protocol.bitswap.pb.Message.Block}
      */
-    public  static final class Block extends
+    public static final class Block extends
         com.google.protobuf.GeneratedMessageV3 implements
-        // @@protoc_insertion_point(message_implements:bitswap.message.pb.Message.Block)
+        // @@protoc_insertion_point(message_implements:org.peergos.protocol.bitswap.pb.Message.Block)
         BlockOrBuilder {
     private static final long serialVersionUID = 0L;
       // Use Block.newBuilder() to construct.
@@ -2451,6 +2576,13 @@ public final class MessageOuterClass {
         prefix_ = com.google.protobuf.ByteString.EMPTY;
         data_ = com.google.protobuf.ByteString.EMPTY;
         auth_ = com.google.protobuf.ByteString.EMPTY;
+      }
+
+      @java.lang.Override
+      @SuppressWarnings({"unused"})
+      protected java.lang.Object newInstance(
+          UnusedPrivateParameter unused) {
+        return new Block();
       }
 
       @java.lang.Override
@@ -2466,7 +2598,6 @@ public final class MessageOuterClass {
         if (extensionRegistry == null) {
           throw new java.lang.NullPointerException();
         }
-        int mutable_bitField0_ = 0;
         com.google.protobuf.UnknownFieldSet.Builder unknownFields =
             com.google.protobuf.UnknownFieldSet.newBuilder();
         try {
@@ -2493,7 +2624,7 @@ public final class MessageOuterClass {
                 break;
               }
               default: {
-                if (!parseUnknownFieldProto3(
+                if (!parseUnknownField(
                     input, unknownFields, extensionRegistry, tag)) {
                   done = true;
                 }
@@ -2513,15 +2644,15 @@ public final class MessageOuterClass {
       }
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return MessageOuterClass.internal_static_bitswap_message_pb_Message_Block_descriptor;
+        return org.peergos.protocol.bitswap.pb.MessageOuterClass.internal_static_bitswap_message_pb_Message_Block_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return MessageOuterClass.internal_static_bitswap_message_pb_Message_Block_fieldAccessorTable
+        return org.peergos.protocol.bitswap.pb.MessageOuterClass.internal_static_bitswap_message_pb_Message_Block_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                MessageOuterClass.Message.Block.class, MessageOuterClass.Message.Block.Builder.class);
+                org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block.class, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block.Builder.class);
       }
 
       public static final int PREFIX_FIELD_NUMBER = 1;
@@ -2532,7 +2663,9 @@ public final class MessageOuterClass {
        * </pre>
        *
        * <code>bytes prefix = 1;</code>
+       * @return The prefix.
        */
+      @java.lang.Override
       public com.google.protobuf.ByteString getPrefix() {
         return prefix_;
       }
@@ -2541,7 +2674,9 @@ public final class MessageOuterClass {
       private com.google.protobuf.ByteString data_;
       /**
        * <code>bytes data = 2;</code>
+       * @return The data.
        */
+      @java.lang.Override
       public com.google.protobuf.ByteString getData() {
         return data_;
       }
@@ -2550,7 +2685,9 @@ public final class MessageOuterClass {
       private com.google.protobuf.ByteString auth_;
       /**
        * <code>bytes auth = 3;</code>
+       * @return The auth.
        */
+      @java.lang.Override
       public com.google.protobuf.ByteString getAuth() {
         return auth_;
       }
@@ -2609,20 +2746,19 @@ public final class MessageOuterClass {
         if (obj == this) {
          return true;
         }
-        if (!(obj instanceof MessageOuterClass.Message.Block)) {
+        if (!(obj instanceof org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block)) {
           return super.equals(obj);
         }
-        MessageOuterClass.Message.Block other = (MessageOuterClass.Message.Block) obj;
+        org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block other = (org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block) obj;
 
-        boolean result = true;
-        result = result && getPrefix()
-            .equals(other.getPrefix());
-        result = result && getData()
-            .equals(other.getData());
-        result = result && getAuth()
-            .equals(other.getAuth());
-        result = result && unknownFields.equals(other.unknownFields);
-        return result;
+        if (!getPrefix()
+            .equals(other.getPrefix())) return false;
+        if (!getData()
+            .equals(other.getData())) return false;
+        if (!getAuth()
+            .equals(other.getAuth())) return false;
+        if (!unknownFields.equals(other.unknownFields)) return false;
+        return true;
       }
 
       @java.lang.Override
@@ -2643,69 +2779,69 @@ public final class MessageOuterClass {
         return hash;
       }
 
-      public static MessageOuterClass.Message.Block parseFrom(
+      public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block parseFrom(
           java.nio.ByteBuffer data)
           throws com.google.protobuf.InvalidProtocolBufferException {
         return PARSER.parseFrom(data);
       }
-      public static MessageOuterClass.Message.Block parseFrom(
+      public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block parseFrom(
           java.nio.ByteBuffer data,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
         return PARSER.parseFrom(data, extensionRegistry);
       }
-      public static MessageOuterClass.Message.Block parseFrom(
+      public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block parseFrom(
           com.google.protobuf.ByteString data)
           throws com.google.protobuf.InvalidProtocolBufferException {
         return PARSER.parseFrom(data);
       }
-      public static MessageOuterClass.Message.Block parseFrom(
+      public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block parseFrom(
           com.google.protobuf.ByteString data,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
         return PARSER.parseFrom(data, extensionRegistry);
       }
-      public static MessageOuterClass.Message.Block parseFrom(byte[] data)
+      public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block parseFrom(byte[] data)
           throws com.google.protobuf.InvalidProtocolBufferException {
         return PARSER.parseFrom(data);
       }
-      public static MessageOuterClass.Message.Block parseFrom(
+      public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block parseFrom(
           byte[] data,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
         return PARSER.parseFrom(data, extensionRegistry);
       }
-      public static MessageOuterClass.Message.Block parseFrom(java.io.InputStream input)
+      public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block parseFrom(java.io.InputStream input)
           throws java.io.IOException {
         return com.google.protobuf.GeneratedMessageV3
             .parseWithIOException(PARSER, input);
       }
-      public static MessageOuterClass.Message.Block parseFrom(
+      public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block parseFrom(
           java.io.InputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
         return com.google.protobuf.GeneratedMessageV3
             .parseWithIOException(PARSER, input, extensionRegistry);
       }
-      public static MessageOuterClass.Message.Block parseDelimitedFrom(java.io.InputStream input)
+      public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block parseDelimitedFrom(java.io.InputStream input)
           throws java.io.IOException {
         return com.google.protobuf.GeneratedMessageV3
             .parseDelimitedWithIOException(PARSER, input);
       }
-      public static MessageOuterClass.Message.Block parseDelimitedFrom(
+      public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block parseDelimitedFrom(
           java.io.InputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
         return com.google.protobuf.GeneratedMessageV3
             .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
       }
-      public static MessageOuterClass.Message.Block parseFrom(
+      public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block parseFrom(
           com.google.protobuf.CodedInputStream input)
           throws java.io.IOException {
         return com.google.protobuf.GeneratedMessageV3
             .parseWithIOException(PARSER, input);
       }
-      public static MessageOuterClass.Message.Block parseFrom(
+      public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block parseFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
@@ -2718,7 +2854,7 @@ public final class MessageOuterClass {
       public static Builder newBuilder() {
         return DEFAULT_INSTANCE.toBuilder();
       }
-      public static Builder newBuilder(MessageOuterClass.Message.Block prototype) {
+      public static Builder newBuilder(org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block prototype) {
         return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
       }
       @java.lang.Override
@@ -2734,26 +2870,26 @@ public final class MessageOuterClass {
         return builder;
       }
       /**
-       * Protobuf type {@code bitswap.message.pb.Message.Block}
+       * Protobuf type {@code org.peergos.protocol.bitswap.pb.Message.Block}
        */
       public static final class Builder extends
           com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-          // @@protoc_insertion_point(builder_implements:bitswap.message.pb.Message.Block)
-          MessageOuterClass.Message.BlockOrBuilder {
+          // @@protoc_insertion_point(builder_implements:org.peergos.protocol.bitswap.pb.Message.Block)
+          org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockOrBuilder {
         public static final com.google.protobuf.Descriptors.Descriptor
             getDescriptor() {
-          return MessageOuterClass.internal_static_bitswap_message_pb_Message_Block_descriptor;
+          return org.peergos.protocol.bitswap.pb.MessageOuterClass.internal_static_bitswap_message_pb_Message_Block_descriptor;
         }
 
         @java.lang.Override
         protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
             internalGetFieldAccessorTable() {
-          return MessageOuterClass.internal_static_bitswap_message_pb_Message_Block_fieldAccessorTable
+          return org.peergos.protocol.bitswap.pb.MessageOuterClass.internal_static_bitswap_message_pb_Message_Block_fieldAccessorTable
               .ensureFieldAccessorsInitialized(
-                  MessageOuterClass.Message.Block.class, MessageOuterClass.Message.Block.Builder.class);
+                  org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block.class, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block.Builder.class);
         }
 
-        // Construct using bitswap.message.pb.MessageOuterClass.Message.Block.newBuilder()
+        // Construct using org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block.newBuilder()
         private Builder() {
           maybeForceBuilderInitialization();
         }
@@ -2783,17 +2919,17 @@ public final class MessageOuterClass {
         @java.lang.Override
         public com.google.protobuf.Descriptors.Descriptor
             getDescriptorForType() {
-          return MessageOuterClass.internal_static_bitswap_message_pb_Message_Block_descriptor;
+          return org.peergos.protocol.bitswap.pb.MessageOuterClass.internal_static_bitswap_message_pb_Message_Block_descriptor;
         }
 
         @java.lang.Override
-        public MessageOuterClass.Message.Block getDefaultInstanceForType() {
-          return MessageOuterClass.Message.Block.getDefaultInstance();
+        public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block getDefaultInstanceForType() {
+          return org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block.getDefaultInstance();
         }
 
         @java.lang.Override
-        public MessageOuterClass.Message.Block build() {
-          MessageOuterClass.Message.Block result = buildPartial();
+        public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block build() {
+          org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block result = buildPartial();
           if (!result.isInitialized()) {
             throw newUninitializedMessageException(result);
           }
@@ -2801,8 +2937,8 @@ public final class MessageOuterClass {
         }
 
         @java.lang.Override
-        public MessageOuterClass.Message.Block buildPartial() {
-          MessageOuterClass.Message.Block result = new MessageOuterClass.Message.Block(this);
+        public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block buildPartial() {
+          org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block result = new org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block(this);
           result.prefix_ = prefix_;
           result.data_ = data_;
           result.auth_ = auth_;
@@ -2812,48 +2948,48 @@ public final class MessageOuterClass {
 
         @java.lang.Override
         public Builder clone() {
-          return (Builder) super.clone();
+          return super.clone();
         }
         @java.lang.Override
         public Builder setField(
             com.google.protobuf.Descriptors.FieldDescriptor field,
             java.lang.Object value) {
-          return (Builder) super.setField(field, value);
+          return super.setField(field, value);
         }
         @java.lang.Override
         public Builder clearField(
             com.google.protobuf.Descriptors.FieldDescriptor field) {
-          return (Builder) super.clearField(field);
+          return super.clearField(field);
         }
         @java.lang.Override
         public Builder clearOneof(
             com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-          return (Builder) super.clearOneof(oneof);
+          return super.clearOneof(oneof);
         }
         @java.lang.Override
         public Builder setRepeatedField(
             com.google.protobuf.Descriptors.FieldDescriptor field,
             int index, java.lang.Object value) {
-          return (Builder) super.setRepeatedField(field, index, value);
+          return super.setRepeatedField(field, index, value);
         }
         @java.lang.Override
         public Builder addRepeatedField(
             com.google.protobuf.Descriptors.FieldDescriptor field,
             java.lang.Object value) {
-          return (Builder) super.addRepeatedField(field, value);
+          return super.addRepeatedField(field, value);
         }
         @java.lang.Override
         public Builder mergeFrom(com.google.protobuf.Message other) {
-          if (other instanceof MessageOuterClass.Message.Block) {
-            return mergeFrom((MessageOuterClass.Message.Block)other);
+          if (other instanceof org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block) {
+            return mergeFrom((org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block)other);
           } else {
             super.mergeFrom(other);
             return this;
           }
         }
 
-        public Builder mergeFrom(MessageOuterClass.Message.Block other) {
-          if (other == MessageOuterClass.Message.Block.getDefaultInstance()) return this;
+        public Builder mergeFrom(org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block other) {
+          if (other == org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block.getDefaultInstance()) return this;
           if (other.getPrefix() != com.google.protobuf.ByteString.EMPTY) {
             setPrefix(other.getPrefix());
           }
@@ -2878,11 +3014,11 @@ public final class MessageOuterClass {
             com.google.protobuf.CodedInputStream input,
             com.google.protobuf.ExtensionRegistryLite extensionRegistry)
             throws java.io.IOException {
-          MessageOuterClass.Message.Block parsedMessage = null;
+          org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block parsedMessage = null;
           try {
             parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
           } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-            parsedMessage = (MessageOuterClass.Message.Block) e.getUnfinishedMessage();
+            parsedMessage = (org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block) e.getUnfinishedMessage();
             throw e.unwrapIOException();
           } finally {
             if (parsedMessage != null) {
@@ -2899,7 +3035,9 @@ public final class MessageOuterClass {
          * </pre>
          *
          * <code>bytes prefix = 1;</code>
+         * @return The prefix.
          */
+        @java.lang.Override
         public com.google.protobuf.ByteString getPrefix() {
           return prefix_;
         }
@@ -2909,6 +3047,8 @@ public final class MessageOuterClass {
          * </pre>
          *
          * <code>bytes prefix = 1;</code>
+         * @param value The prefix to set.
+         * @return This builder for chaining.
          */
         public Builder setPrefix(com.google.protobuf.ByteString value) {
           if (value == null) {
@@ -2925,6 +3065,7 @@ public final class MessageOuterClass {
          * </pre>
          *
          * <code>bytes prefix = 1;</code>
+         * @return This builder for chaining.
          */
         public Builder clearPrefix() {
           
@@ -2936,12 +3077,16 @@ public final class MessageOuterClass {
         private com.google.protobuf.ByteString data_ = com.google.protobuf.ByteString.EMPTY;
         /**
          * <code>bytes data = 2;</code>
+         * @return The data.
          */
+        @java.lang.Override
         public com.google.protobuf.ByteString getData() {
           return data_;
         }
         /**
          * <code>bytes data = 2;</code>
+         * @param value The data to set.
+         * @return This builder for chaining.
          */
         public Builder setData(com.google.protobuf.ByteString value) {
           if (value == null) {
@@ -2954,6 +3099,7 @@ public final class MessageOuterClass {
         }
         /**
          * <code>bytes data = 2;</code>
+         * @return This builder for chaining.
          */
         public Builder clearData() {
           
@@ -2965,12 +3111,16 @@ public final class MessageOuterClass {
         private com.google.protobuf.ByteString auth_ = com.google.protobuf.ByteString.EMPTY;
         /**
          * <code>bytes auth = 3;</code>
+         * @return The auth.
          */
+        @java.lang.Override
         public com.google.protobuf.ByteString getAuth() {
           return auth_;
         }
         /**
          * <code>bytes auth = 3;</code>
+         * @param value The auth to set.
+         * @return This builder for chaining.
          */
         public Builder setAuth(com.google.protobuf.ByteString value) {
           if (value == null) {
@@ -2983,6 +3133,7 @@ public final class MessageOuterClass {
         }
         /**
          * <code>bytes auth = 3;</code>
+         * @return This builder for chaining.
          */
         public Builder clearAuth() {
           
@@ -2993,7 +3144,7 @@ public final class MessageOuterClass {
         @java.lang.Override
         public final Builder setUnknownFields(
             final com.google.protobuf.UnknownFieldSet unknownFields) {
-          return super.setUnknownFieldsProto3(unknownFields);
+          return super.setUnknownFields(unknownFields);
         }
 
         @java.lang.Override
@@ -3003,16 +3154,16 @@ public final class MessageOuterClass {
         }
 
 
-        // @@protoc_insertion_point(builder_scope:bitswap.message.pb.Message.Block)
+        // @@protoc_insertion_point(builder_scope:org.peergos.protocol.bitswap.pb.Message.Block)
       }
 
-      // @@protoc_insertion_point(class_scope:bitswap.message.pb.Message.Block)
-      private static final MessageOuterClass.Message.Block DEFAULT_INSTANCE;
+      // @@protoc_insertion_point(class_scope:org.peergos.protocol.bitswap.pb.Message.Block)
+      private static final org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block DEFAULT_INSTANCE;
       static {
-        DEFAULT_INSTANCE = new MessageOuterClass.Message.Block();
+        DEFAULT_INSTANCE = new org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block();
       }
 
-      public static MessageOuterClass.Message.Block getDefaultInstance() {
+      public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block getDefaultInstance() {
         return DEFAULT_INSTANCE;
       }
 
@@ -3037,14 +3188,14 @@ public final class MessageOuterClass {
       }
 
       @java.lang.Override
-      public MessageOuterClass.Message.Block getDefaultInstanceForType() {
+      public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block getDefaultInstanceForType() {
         return DEFAULT_INSTANCE;
       }
 
     }
 
     public interface BlockPresenceOrBuilder extends
-        // @@protoc_insertion_point(interface_extends:bitswap.message.pb.Message.BlockPresence)
+        // @@protoc_insertion_point(interface_extends:org.peergos.protocol.bitswap.pb.Message.BlockPresence)
         com.google.protobuf.MessageOrBuilder {
 
       /**
@@ -3053,29 +3204,33 @@ public final class MessageOuterClass {
        * </pre>
        *
        * <code>bytes cid = 1;</code>
+       * @return The cid.
        */
       com.google.protobuf.ByteString getCid();
 
       /**
-       * <code>.bitswap.message.pb.Message.BlockPresenceType type = 2;</code>
+       * <code>.org.peergos.protocol.bitswap.pb.Message.BlockPresenceType type = 2;</code>
+       * @return The enum numeric value on the wire for type.
        */
       int getTypeValue();
       /**
-       * <code>.bitswap.message.pb.Message.BlockPresenceType type = 2;</code>
+       * <code>.org.peergos.protocol.bitswap.pb.Message.BlockPresenceType type = 2;</code>
+       * @return The type.
        */
-      MessageOuterClass.Message.BlockPresenceType getType();
+      org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresenceType getType();
 
       /**
        * <code>bytes auth = 3;</code>
+       * @return The auth.
        */
       com.google.protobuf.ByteString getAuth();
     }
     /**
-     * Protobuf type {@code bitswap.message.pb.Message.BlockPresence}
+     * Protobuf type {@code org.peergos.protocol.bitswap.pb.Message.BlockPresence}
      */
-    public  static final class BlockPresence extends
+    public static final class BlockPresence extends
         com.google.protobuf.GeneratedMessageV3 implements
-        // @@protoc_insertion_point(message_implements:bitswap.message.pb.Message.BlockPresence)
+        // @@protoc_insertion_point(message_implements:org.peergos.protocol.bitswap.pb.Message.BlockPresence)
         BlockPresenceOrBuilder {
     private static final long serialVersionUID = 0L;
       // Use BlockPresence.newBuilder() to construct.
@@ -3086,6 +3241,13 @@ public final class MessageOuterClass {
         cid_ = com.google.protobuf.ByteString.EMPTY;
         type_ = 0;
         auth_ = com.google.protobuf.ByteString.EMPTY;
+      }
+
+      @java.lang.Override
+      @SuppressWarnings({"unused"})
+      protected java.lang.Object newInstance(
+          UnusedPrivateParameter unused) {
+        return new BlockPresence();
       }
 
       @java.lang.Override
@@ -3101,7 +3263,6 @@ public final class MessageOuterClass {
         if (extensionRegistry == null) {
           throw new java.lang.NullPointerException();
         }
-        int mutable_bitField0_ = 0;
         com.google.protobuf.UnknownFieldSet.Builder unknownFields =
             com.google.protobuf.UnknownFieldSet.newBuilder();
         try {
@@ -3129,7 +3290,7 @@ public final class MessageOuterClass {
                 break;
               }
               default: {
-                if (!parseUnknownFieldProto3(
+                if (!parseUnknownField(
                     input, unknownFields, extensionRegistry, tag)) {
                   done = true;
                 }
@@ -3149,15 +3310,15 @@ public final class MessageOuterClass {
       }
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return MessageOuterClass.internal_static_bitswap_message_pb_Message_BlockPresence_descriptor;
+        return org.peergos.protocol.bitswap.pb.MessageOuterClass.internal_static_bitswap_message_pb_Message_BlockPresence_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return MessageOuterClass.internal_static_bitswap_message_pb_Message_BlockPresence_fieldAccessorTable
+        return org.peergos.protocol.bitswap.pb.MessageOuterClass.internal_static_bitswap_message_pb_Message_BlockPresence_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                MessageOuterClass.Message.BlockPresence.class, MessageOuterClass.Message.BlockPresence.Builder.class);
+                org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence.class, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence.Builder.class);
       }
 
       public static final int CID_FIELD_NUMBER = 1;
@@ -3168,7 +3329,9 @@ public final class MessageOuterClass {
        * </pre>
        *
        * <code>bytes cid = 1;</code>
+       * @return The cid.
        */
+      @java.lang.Override
       public com.google.protobuf.ByteString getCid() {
         return cid_;
       }
@@ -3176,25 +3339,29 @@ public final class MessageOuterClass {
       public static final int TYPE_FIELD_NUMBER = 2;
       private int type_;
       /**
-       * <code>.bitswap.message.pb.Message.BlockPresenceType type = 2;</code>
+       * <code>.org.peergos.protocol.bitswap.pb.Message.BlockPresenceType type = 2;</code>
+       * @return The enum numeric value on the wire for type.
        */
-      public int getTypeValue() {
+      @java.lang.Override public int getTypeValue() {
         return type_;
       }
       /**
-       * <code>.bitswap.message.pb.Message.BlockPresenceType type = 2;</code>
+       * <code>.org.peergos.protocol.bitswap.pb.Message.BlockPresenceType type = 2;</code>
+       * @return The type.
        */
-      public MessageOuterClass.Message.BlockPresenceType getType() {
+      @java.lang.Override public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresenceType getType() {
         @SuppressWarnings("deprecation")
-        MessageOuterClass.Message.BlockPresenceType result = MessageOuterClass.Message.BlockPresenceType.valueOf(type_);
-        return result == null ? MessageOuterClass.Message.BlockPresenceType.UNRECOGNIZED : result;
+        org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresenceType result = org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresenceType.valueOf(type_);
+        return result == null ? org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresenceType.UNRECOGNIZED : result;
       }
 
       public static final int AUTH_FIELD_NUMBER = 3;
       private com.google.protobuf.ByteString auth_;
       /**
        * <code>bytes auth = 3;</code>
+       * @return The auth.
        */
+      @java.lang.Override
       public com.google.protobuf.ByteString getAuth() {
         return auth_;
       }
@@ -3216,7 +3383,7 @@ public final class MessageOuterClass {
         if (!cid_.isEmpty()) {
           output.writeBytes(1, cid_);
         }
-        if (type_ != MessageOuterClass.Message.BlockPresenceType.Have.getNumber()) {
+        if (type_ != org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresenceType.Have.getNumber()) {
           output.writeEnum(2, type_);
         }
         if (!auth_.isEmpty()) {
@@ -3235,7 +3402,7 @@ public final class MessageOuterClass {
           size += com.google.protobuf.CodedOutputStream
             .computeBytesSize(1, cid_);
         }
-        if (type_ != MessageOuterClass.Message.BlockPresenceType.Have.getNumber()) {
+        if (type_ != org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresenceType.Have.getNumber()) {
           size += com.google.protobuf.CodedOutputStream
             .computeEnumSize(2, type_);
         }
@@ -3253,19 +3420,18 @@ public final class MessageOuterClass {
         if (obj == this) {
          return true;
         }
-        if (!(obj instanceof MessageOuterClass.Message.BlockPresence)) {
+        if (!(obj instanceof org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence)) {
           return super.equals(obj);
         }
-        MessageOuterClass.Message.BlockPresence other = (MessageOuterClass.Message.BlockPresence) obj;
+        org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence other = (org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence) obj;
 
-        boolean result = true;
-        result = result && getCid()
-            .equals(other.getCid());
-        result = result && type_ == other.type_;
-        result = result && getAuth()
-            .equals(other.getAuth());
-        result = result && unknownFields.equals(other.unknownFields);
-        return result;
+        if (!getCid()
+            .equals(other.getCid())) return false;
+        if (type_ != other.type_) return false;
+        if (!getAuth()
+            .equals(other.getAuth())) return false;
+        if (!unknownFields.equals(other.unknownFields)) return false;
+        return true;
       }
 
       @java.lang.Override
@@ -3286,69 +3452,69 @@ public final class MessageOuterClass {
         return hash;
       }
 
-      public static MessageOuterClass.Message.BlockPresence parseFrom(
+      public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence parseFrom(
           java.nio.ByteBuffer data)
           throws com.google.protobuf.InvalidProtocolBufferException {
         return PARSER.parseFrom(data);
       }
-      public static MessageOuterClass.Message.BlockPresence parseFrom(
+      public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence parseFrom(
           java.nio.ByteBuffer data,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
         return PARSER.parseFrom(data, extensionRegistry);
       }
-      public static MessageOuterClass.Message.BlockPresence parseFrom(
+      public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence parseFrom(
           com.google.protobuf.ByteString data)
           throws com.google.protobuf.InvalidProtocolBufferException {
         return PARSER.parseFrom(data);
       }
-      public static MessageOuterClass.Message.BlockPresence parseFrom(
+      public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence parseFrom(
           com.google.protobuf.ByteString data,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
         return PARSER.parseFrom(data, extensionRegistry);
       }
-      public static MessageOuterClass.Message.BlockPresence parseFrom(byte[] data)
+      public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence parseFrom(byte[] data)
           throws com.google.protobuf.InvalidProtocolBufferException {
         return PARSER.parseFrom(data);
       }
-      public static MessageOuterClass.Message.BlockPresence parseFrom(
+      public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence parseFrom(
           byte[] data,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
         return PARSER.parseFrom(data, extensionRegistry);
       }
-      public static MessageOuterClass.Message.BlockPresence parseFrom(java.io.InputStream input)
+      public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence parseFrom(java.io.InputStream input)
           throws java.io.IOException {
         return com.google.protobuf.GeneratedMessageV3
             .parseWithIOException(PARSER, input);
       }
-      public static MessageOuterClass.Message.BlockPresence parseFrom(
+      public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence parseFrom(
           java.io.InputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
         return com.google.protobuf.GeneratedMessageV3
             .parseWithIOException(PARSER, input, extensionRegistry);
       }
-      public static MessageOuterClass.Message.BlockPresence parseDelimitedFrom(java.io.InputStream input)
+      public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence parseDelimitedFrom(java.io.InputStream input)
           throws java.io.IOException {
         return com.google.protobuf.GeneratedMessageV3
             .parseDelimitedWithIOException(PARSER, input);
       }
-      public static MessageOuterClass.Message.BlockPresence parseDelimitedFrom(
+      public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence parseDelimitedFrom(
           java.io.InputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
         return com.google.protobuf.GeneratedMessageV3
             .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
       }
-      public static MessageOuterClass.Message.BlockPresence parseFrom(
+      public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence parseFrom(
           com.google.protobuf.CodedInputStream input)
           throws java.io.IOException {
         return com.google.protobuf.GeneratedMessageV3
             .parseWithIOException(PARSER, input);
       }
-      public static MessageOuterClass.Message.BlockPresence parseFrom(
+      public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence parseFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
@@ -3361,7 +3527,7 @@ public final class MessageOuterClass {
       public static Builder newBuilder() {
         return DEFAULT_INSTANCE.toBuilder();
       }
-      public static Builder newBuilder(MessageOuterClass.Message.BlockPresence prototype) {
+      public static Builder newBuilder(org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence prototype) {
         return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
       }
       @java.lang.Override
@@ -3377,26 +3543,26 @@ public final class MessageOuterClass {
         return builder;
       }
       /**
-       * Protobuf type {@code bitswap.message.pb.Message.BlockPresence}
+       * Protobuf type {@code org.peergos.protocol.bitswap.pb.Message.BlockPresence}
        */
       public static final class Builder extends
           com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-          // @@protoc_insertion_point(builder_implements:bitswap.message.pb.Message.BlockPresence)
-          MessageOuterClass.Message.BlockPresenceOrBuilder {
+          // @@protoc_insertion_point(builder_implements:org.peergos.protocol.bitswap.pb.Message.BlockPresence)
+          org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresenceOrBuilder {
         public static final com.google.protobuf.Descriptors.Descriptor
             getDescriptor() {
-          return MessageOuterClass.internal_static_bitswap_message_pb_Message_BlockPresence_descriptor;
+          return org.peergos.protocol.bitswap.pb.MessageOuterClass.internal_static_bitswap_message_pb_Message_BlockPresence_descriptor;
         }
 
         @java.lang.Override
         protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
             internalGetFieldAccessorTable() {
-          return MessageOuterClass.internal_static_bitswap_message_pb_Message_BlockPresence_fieldAccessorTable
+          return org.peergos.protocol.bitswap.pb.MessageOuterClass.internal_static_bitswap_message_pb_Message_BlockPresence_fieldAccessorTable
               .ensureFieldAccessorsInitialized(
-                  MessageOuterClass.Message.BlockPresence.class, MessageOuterClass.Message.BlockPresence.Builder.class);
+                  org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence.class, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence.Builder.class);
         }
 
-        // Construct using bitswap.message.pb.MessageOuterClass.Message.BlockPresence.newBuilder()
+        // Construct using org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence.newBuilder()
         private Builder() {
           maybeForceBuilderInitialization();
         }
@@ -3426,17 +3592,17 @@ public final class MessageOuterClass {
         @java.lang.Override
         public com.google.protobuf.Descriptors.Descriptor
             getDescriptorForType() {
-          return MessageOuterClass.internal_static_bitswap_message_pb_Message_BlockPresence_descriptor;
+          return org.peergos.protocol.bitswap.pb.MessageOuterClass.internal_static_bitswap_message_pb_Message_BlockPresence_descriptor;
         }
 
         @java.lang.Override
-        public MessageOuterClass.Message.BlockPresence getDefaultInstanceForType() {
-          return MessageOuterClass.Message.BlockPresence.getDefaultInstance();
+        public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence getDefaultInstanceForType() {
+          return org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence.getDefaultInstance();
         }
 
         @java.lang.Override
-        public MessageOuterClass.Message.BlockPresence build() {
-          MessageOuterClass.Message.BlockPresence result = buildPartial();
+        public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence build() {
+          org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence result = buildPartial();
           if (!result.isInitialized()) {
             throw newUninitializedMessageException(result);
           }
@@ -3444,8 +3610,8 @@ public final class MessageOuterClass {
         }
 
         @java.lang.Override
-        public MessageOuterClass.Message.BlockPresence buildPartial() {
-          MessageOuterClass.Message.BlockPresence result = new MessageOuterClass.Message.BlockPresence(this);
+        public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence buildPartial() {
+          org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence result = new org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence(this);
           result.cid_ = cid_;
           result.type_ = type_;
           result.auth_ = auth_;
@@ -3455,48 +3621,48 @@ public final class MessageOuterClass {
 
         @java.lang.Override
         public Builder clone() {
-          return (Builder) super.clone();
+          return super.clone();
         }
         @java.lang.Override
         public Builder setField(
             com.google.protobuf.Descriptors.FieldDescriptor field,
             java.lang.Object value) {
-          return (Builder) super.setField(field, value);
+          return super.setField(field, value);
         }
         @java.lang.Override
         public Builder clearField(
             com.google.protobuf.Descriptors.FieldDescriptor field) {
-          return (Builder) super.clearField(field);
+          return super.clearField(field);
         }
         @java.lang.Override
         public Builder clearOneof(
             com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-          return (Builder) super.clearOneof(oneof);
+          return super.clearOneof(oneof);
         }
         @java.lang.Override
         public Builder setRepeatedField(
             com.google.protobuf.Descriptors.FieldDescriptor field,
             int index, java.lang.Object value) {
-          return (Builder) super.setRepeatedField(field, index, value);
+          return super.setRepeatedField(field, index, value);
         }
         @java.lang.Override
         public Builder addRepeatedField(
             com.google.protobuf.Descriptors.FieldDescriptor field,
             java.lang.Object value) {
-          return (Builder) super.addRepeatedField(field, value);
+          return super.addRepeatedField(field, value);
         }
         @java.lang.Override
         public Builder mergeFrom(com.google.protobuf.Message other) {
-          if (other instanceof MessageOuterClass.Message.BlockPresence) {
-            return mergeFrom((MessageOuterClass.Message.BlockPresence)other);
+          if (other instanceof org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence) {
+            return mergeFrom((org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence)other);
           } else {
             super.mergeFrom(other);
             return this;
           }
         }
 
-        public Builder mergeFrom(MessageOuterClass.Message.BlockPresence other) {
-          if (other == MessageOuterClass.Message.BlockPresence.getDefaultInstance()) return this;
+        public Builder mergeFrom(org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence other) {
+          if (other == org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence.getDefaultInstance()) return this;
           if (other.getCid() != com.google.protobuf.ByteString.EMPTY) {
             setCid(other.getCid());
           }
@@ -3521,11 +3687,11 @@ public final class MessageOuterClass {
             com.google.protobuf.CodedInputStream input,
             com.google.protobuf.ExtensionRegistryLite extensionRegistry)
             throws java.io.IOException {
-          MessageOuterClass.Message.BlockPresence parsedMessage = null;
+          org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence parsedMessage = null;
           try {
             parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
           } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-            parsedMessage = (MessageOuterClass.Message.BlockPresence) e.getUnfinishedMessage();
+            parsedMessage = (org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence) e.getUnfinishedMessage();
             throw e.unwrapIOException();
           } finally {
             if (parsedMessage != null) {
@@ -3542,7 +3708,9 @@ public final class MessageOuterClass {
          * </pre>
          *
          * <code>bytes cid = 1;</code>
+         * @return The cid.
          */
+        @java.lang.Override
         public com.google.protobuf.ByteString getCid() {
           return cid_;
         }
@@ -3552,6 +3720,8 @@ public final class MessageOuterClass {
          * </pre>
          *
          * <code>bytes cid = 1;</code>
+         * @param value The cid to set.
+         * @return This builder for chaining.
          */
         public Builder setCid(com.google.protobuf.ByteString value) {
           if (value == null) {
@@ -3568,6 +3738,7 @@ public final class MessageOuterClass {
          * </pre>
          *
          * <code>bytes cid = 1;</code>
+         * @return This builder for chaining.
          */
         public Builder clearCid() {
           
@@ -3578,31 +3749,39 @@ public final class MessageOuterClass {
 
         private int type_ = 0;
         /**
-         * <code>.bitswap.message.pb.Message.BlockPresenceType type = 2;</code>
+         * <code>.org.peergos.protocol.bitswap.pb.Message.BlockPresenceType type = 2;</code>
+         * @return The enum numeric value on the wire for type.
          */
-        public int getTypeValue() {
+        @java.lang.Override public int getTypeValue() {
           return type_;
         }
         /**
-         * <code>.bitswap.message.pb.Message.BlockPresenceType type = 2;</code>
+         * <code>.org.peergos.protocol.bitswap.pb.Message.BlockPresenceType type = 2;</code>
+         * @param value The enum numeric value on the wire for type to set.
+         * @return This builder for chaining.
          */
         public Builder setTypeValue(int value) {
+          
           type_ = value;
           onChanged();
           return this;
         }
         /**
-         * <code>.bitswap.message.pb.Message.BlockPresenceType type = 2;</code>
+         * <code>.org.peergos.protocol.bitswap.pb.Message.BlockPresenceType type = 2;</code>
+         * @return The type.
          */
-        public MessageOuterClass.Message.BlockPresenceType getType() {
+        @java.lang.Override
+        public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresenceType getType() {
           @SuppressWarnings("deprecation")
-          MessageOuterClass.Message.BlockPresenceType result = MessageOuterClass.Message.BlockPresenceType.valueOf(type_);
-          return result == null ? MessageOuterClass.Message.BlockPresenceType.UNRECOGNIZED : result;
+          org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresenceType result = org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresenceType.valueOf(type_);
+          return result == null ? org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresenceType.UNRECOGNIZED : result;
         }
         /**
-         * <code>.bitswap.message.pb.Message.BlockPresenceType type = 2;</code>
+         * <code>.org.peergos.protocol.bitswap.pb.Message.BlockPresenceType type = 2;</code>
+         * @param value The type to set.
+         * @return This builder for chaining.
          */
-        public Builder setType(MessageOuterClass.Message.BlockPresenceType value) {
+        public Builder setType(org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresenceType value) {
           if (value == null) {
             throw new NullPointerException();
           }
@@ -3612,7 +3791,8 @@ public final class MessageOuterClass {
           return this;
         }
         /**
-         * <code>.bitswap.message.pb.Message.BlockPresenceType type = 2;</code>
+         * <code>.org.peergos.protocol.bitswap.pb.Message.BlockPresenceType type = 2;</code>
+         * @return This builder for chaining.
          */
         public Builder clearType() {
           
@@ -3624,12 +3804,16 @@ public final class MessageOuterClass {
         private com.google.protobuf.ByteString auth_ = com.google.protobuf.ByteString.EMPTY;
         /**
          * <code>bytes auth = 3;</code>
+         * @return The auth.
          */
+        @java.lang.Override
         public com.google.protobuf.ByteString getAuth() {
           return auth_;
         }
         /**
          * <code>bytes auth = 3;</code>
+         * @param value The auth to set.
+         * @return This builder for chaining.
          */
         public Builder setAuth(com.google.protobuf.ByteString value) {
           if (value == null) {
@@ -3642,6 +3826,7 @@ public final class MessageOuterClass {
         }
         /**
          * <code>bytes auth = 3;</code>
+         * @return This builder for chaining.
          */
         public Builder clearAuth() {
           
@@ -3652,7 +3837,7 @@ public final class MessageOuterClass {
         @java.lang.Override
         public final Builder setUnknownFields(
             final com.google.protobuf.UnknownFieldSet unknownFields) {
-          return super.setUnknownFieldsProto3(unknownFields);
+          return super.setUnknownFields(unknownFields);
         }
 
         @java.lang.Override
@@ -3662,16 +3847,16 @@ public final class MessageOuterClass {
         }
 
 
-        // @@protoc_insertion_point(builder_scope:bitswap.message.pb.Message.BlockPresence)
+        // @@protoc_insertion_point(builder_scope:org.peergos.protocol.bitswap.pb.Message.BlockPresence)
       }
 
-      // @@protoc_insertion_point(class_scope:bitswap.message.pb.Message.BlockPresence)
-      private static final MessageOuterClass.Message.BlockPresence DEFAULT_INSTANCE;
+      // @@protoc_insertion_point(class_scope:org.peergos.protocol.bitswap.pb.Message.BlockPresence)
+      private static final org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence DEFAULT_INSTANCE;
       static {
-        DEFAULT_INSTANCE = new MessageOuterClass.Message.BlockPresence();
+        DEFAULT_INSTANCE = new org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence();
       }
 
-      public static MessageOuterClass.Message.BlockPresence getDefaultInstance() {
+      public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence getDefaultInstance() {
         return DEFAULT_INSTANCE;
       }
 
@@ -3696,22 +3881,23 @@ public final class MessageOuterClass {
       }
 
       @java.lang.Override
-      public MessageOuterClass.Message.BlockPresence getDefaultInstanceForType() {
+      public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence getDefaultInstanceForType() {
         return DEFAULT_INSTANCE;
       }
 
     }
 
-    private int bitField0_;
     public static final int WANTLIST_FIELD_NUMBER = 1;
-    private MessageOuterClass.Message.Wantlist wantlist_;
+    private org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist wantlist_;
     /**
      * <pre>
      *[(gogoproto.nullable) = false];
      * </pre>
      *
-     * <code>.bitswap.message.pb.Message.Wantlist wantlist = 1;</code>
+     * <code>.org.peergos.protocol.bitswap.pb.Message.Wantlist wantlist = 1;</code>
+     * @return Whether the wantlist field is set.
      */
+    @java.lang.Override
     public boolean hasWantlist() {
       return wantlist_ != null;
     }
@@ -3720,19 +3906,22 @@ public final class MessageOuterClass {
      *[(gogoproto.nullable) = false];
      * </pre>
      *
-     * <code>.bitswap.message.pb.Message.Wantlist wantlist = 1;</code>
+     * <code>.org.peergos.protocol.bitswap.pb.Message.Wantlist wantlist = 1;</code>
+     * @return The wantlist.
      */
-    public MessageOuterClass.Message.Wantlist getWantlist() {
-      return wantlist_ == null ? MessageOuterClass.Message.Wantlist.getDefaultInstance() : wantlist_;
+    @java.lang.Override
+    public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist getWantlist() {
+      return wantlist_ == null ? org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.getDefaultInstance() : wantlist_;
     }
     /**
      * <pre>
      *[(gogoproto.nullable) = false];
      * </pre>
      *
-     * <code>.bitswap.message.pb.Message.Wantlist wantlist = 1;</code>
+     * <code>.org.peergos.protocol.bitswap.pb.Message.Wantlist wantlist = 1;</code>
      */
-    public MessageOuterClass.Message.WantlistOrBuilder getWantlistOrBuilder() {
+    @java.lang.Override
+    public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.WantlistOrBuilder getWantlistOrBuilder() {
       return getWantlist();
     }
 
@@ -3744,7 +3933,9 @@ public final class MessageOuterClass {
      * </pre>
      *
      * <code>repeated bytes blocks = 2;</code>
+     * @return A list containing the blocks.
      */
+    @java.lang.Override
     public java.util.List<com.google.protobuf.ByteString>
         getBlocksList() {
       return blocks_;
@@ -3755,6 +3946,7 @@ public final class MessageOuterClass {
      * </pre>
      *
      * <code>repeated bytes blocks = 2;</code>
+     * @return The count of blocks.
      */
     public int getBlocksCount() {
       return blocks_.size();
@@ -3765,21 +3957,24 @@ public final class MessageOuterClass {
      * </pre>
      *
      * <code>repeated bytes blocks = 2;</code>
+     * @param index The index of the element to return.
+     * @return The blocks at the given index.
      */
     public com.google.protobuf.ByteString getBlocks(int index) {
       return blocks_.get(index);
     }
 
     public static final int PAYLOAD_FIELD_NUMBER = 3;
-    private java.util.List<MessageOuterClass.Message.Block> payload_;
+    private java.util.List<org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block> payload_;
     /**
      * <pre>
      *[(gogoproto.nullable) = false];		// used to send Blocks in bitswap 1.1.0
      * </pre>
      *
-     * <code>repeated .bitswap.message.pb.Message.Block payload = 3;</code>
+     * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Block payload = 3;</code>
      */
-    public java.util.List<MessageOuterClass.Message.Block> getPayloadList() {
+    @java.lang.Override
+    public java.util.List<org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block> getPayloadList() {
       return payload_;
     }
     /**
@@ -3787,9 +3982,10 @@ public final class MessageOuterClass {
      *[(gogoproto.nullable) = false];		// used to send Blocks in bitswap 1.1.0
      * </pre>
      *
-     * <code>repeated .bitswap.message.pb.Message.Block payload = 3;</code>
+     * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Block payload = 3;</code>
      */
-    public java.util.List<? extends MessageOuterClass.Message.BlockOrBuilder>
+    @java.lang.Override
+    public java.util.List<? extends org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockOrBuilder> 
         getPayloadOrBuilderList() {
       return payload_;
     }
@@ -3798,8 +3994,9 @@ public final class MessageOuterClass {
      *[(gogoproto.nullable) = false];		// used to send Blocks in bitswap 1.1.0
      * </pre>
      *
-     * <code>repeated .bitswap.message.pb.Message.Block payload = 3;</code>
+     * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Block payload = 3;</code>
      */
+    @java.lang.Override
     public int getPayloadCount() {
       return payload_.size();
     }
@@ -3808,9 +4005,10 @@ public final class MessageOuterClass {
      *[(gogoproto.nullable) = false];		// used to send Blocks in bitswap 1.1.0
      * </pre>
      *
-     * <code>repeated .bitswap.message.pb.Message.Block payload = 3;</code>
+     * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Block payload = 3;</code>
      */
-    public MessageOuterClass.Message.Block getPayload(int index) {
+    @java.lang.Override
+    public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block getPayload(int index) {
       return payload_.get(index);
     }
     /**
@@ -3818,23 +4016,25 @@ public final class MessageOuterClass {
      *[(gogoproto.nullable) = false];		// used to send Blocks in bitswap 1.1.0
      * </pre>
      *
-     * <code>repeated .bitswap.message.pb.Message.Block payload = 3;</code>
+     * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Block payload = 3;</code>
      */
-    public MessageOuterClass.Message.BlockOrBuilder getPayloadOrBuilder(
+    @java.lang.Override
+    public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockOrBuilder getPayloadOrBuilder(
         int index) {
       return payload_.get(index);
     }
 
     public static final int BLOCKPRESENCES_FIELD_NUMBER = 4;
-    private java.util.List<MessageOuterClass.Message.BlockPresence> blockPresences_;
+    private java.util.List<org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence> blockPresences_;
     /**
      * <pre>
      *[(gogoproto.nullable) = false];
      * </pre>
      *
-     * <code>repeated .bitswap.message.pb.Message.BlockPresence blockPresences = 4;</code>
+     * <code>repeated .org.peergos.protocol.bitswap.pb.Message.BlockPresence blockPresences = 4;</code>
      */
-    public java.util.List<MessageOuterClass.Message.BlockPresence> getBlockPresencesList() {
+    @java.lang.Override
+    public java.util.List<org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence> getBlockPresencesList() {
       return blockPresences_;
     }
     /**
@@ -3842,9 +4042,10 @@ public final class MessageOuterClass {
      *[(gogoproto.nullable) = false];
      * </pre>
      *
-     * <code>repeated .bitswap.message.pb.Message.BlockPresence blockPresences = 4;</code>
+     * <code>repeated .org.peergos.protocol.bitswap.pb.Message.BlockPresence blockPresences = 4;</code>
      */
-    public java.util.List<? extends MessageOuterClass.Message.BlockPresenceOrBuilder>
+    @java.lang.Override
+    public java.util.List<? extends org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresenceOrBuilder> 
         getBlockPresencesOrBuilderList() {
       return blockPresences_;
     }
@@ -3853,8 +4054,9 @@ public final class MessageOuterClass {
      *[(gogoproto.nullable) = false];
      * </pre>
      *
-     * <code>repeated .bitswap.message.pb.Message.BlockPresence blockPresences = 4;</code>
+     * <code>repeated .org.peergos.protocol.bitswap.pb.Message.BlockPresence blockPresences = 4;</code>
      */
+    @java.lang.Override
     public int getBlockPresencesCount() {
       return blockPresences_.size();
     }
@@ -3863,9 +4065,10 @@ public final class MessageOuterClass {
      *[(gogoproto.nullable) = false];
      * </pre>
      *
-     * <code>repeated .bitswap.message.pb.Message.BlockPresence blockPresences = 4;</code>
+     * <code>repeated .org.peergos.protocol.bitswap.pb.Message.BlockPresence blockPresences = 4;</code>
      */
-    public MessageOuterClass.Message.BlockPresence getBlockPresences(int index) {
+    @java.lang.Override
+    public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence getBlockPresences(int index) {
       return blockPresences_.get(index);
     }
     /**
@@ -3873,9 +4076,10 @@ public final class MessageOuterClass {
      *[(gogoproto.nullable) = false];
      * </pre>
      *
-     * <code>repeated .bitswap.message.pb.Message.BlockPresence blockPresences = 4;</code>
+     * <code>repeated .org.peergos.protocol.bitswap.pb.Message.BlockPresence blockPresences = 4;</code>
      */
-    public MessageOuterClass.Message.BlockPresenceOrBuilder getBlockPresencesOrBuilder(
+    @java.lang.Override
+    public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresenceOrBuilder getBlockPresencesOrBuilder(
         int index) {
       return blockPresences_.get(index);
     }
@@ -3884,9 +4088,49 @@ public final class MessageOuterClass {
     private int pendingBytes_;
     /**
      * <code>int32 pendingBytes = 5;</code>
+     * @return The pendingBytes.
      */
+    @java.lang.Override
     public int getPendingBytes() {
       return pendingBytes_;
+    }
+
+    public static final int TRACEID_FIELD_NUMBER = 6;
+    private volatile java.lang.Object traceId_;
+    /**
+     * <code>string traceId = 6;</code>
+     * @return The traceId.
+     */
+    @java.lang.Override
+    public java.lang.String getTraceId() {
+      java.lang.Object ref = traceId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        traceId_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>string traceId = 6;</code>
+     * @return The bytes for traceId.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getTraceIdBytes() {
+      java.lang.Object ref = traceId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        traceId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
     }
 
     private byte memoizedIsInitialized = -1;
@@ -3917,6 +4161,9 @@ public final class MessageOuterClass {
       }
       if (pendingBytes_ != 0) {
         output.writeInt32(5, pendingBytes_);
+      }
+      if (!getTraceIdBytes().isEmpty()) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 6, traceId_);
       }
       unknownFields.writeTo(output);
     }
@@ -3952,6 +4199,9 @@ public final class MessageOuterClass {
         size += com.google.protobuf.CodedOutputStream
           .computeInt32Size(5, pendingBytes_);
       }
+      if (!getTraceIdBytes().isEmpty()) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(6, traceId_);
+      }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
       return size;
@@ -3962,27 +4212,28 @@ public final class MessageOuterClass {
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof MessageOuterClass.Message)) {
+      if (!(obj instanceof org.peergos.protocol.bitswap.pb.MessageOuterClass.Message)) {
         return super.equals(obj);
       }
-      MessageOuterClass.Message other = (MessageOuterClass.Message) obj;
+      org.peergos.protocol.bitswap.pb.MessageOuterClass.Message other = (org.peergos.protocol.bitswap.pb.MessageOuterClass.Message) obj;
 
-      boolean result = true;
-      result = result && (hasWantlist() == other.hasWantlist());
+      if (hasWantlist() != other.hasWantlist()) return false;
       if (hasWantlist()) {
-        result = result && getWantlist()
-            .equals(other.getWantlist());
+        if (!getWantlist()
+            .equals(other.getWantlist())) return false;
       }
-      result = result && getBlocksList()
-          .equals(other.getBlocksList());
-      result = result && getPayloadList()
-          .equals(other.getPayloadList());
-      result = result && getBlockPresencesList()
-          .equals(other.getBlockPresencesList());
-      result = result && (getPendingBytes()
-          == other.getPendingBytes());
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!getBlocksList()
+          .equals(other.getBlocksList())) return false;
+      if (!getPayloadList()
+          .equals(other.getPayloadList())) return false;
+      if (!getBlockPresencesList()
+          .equals(other.getBlockPresencesList())) return false;
+      if (getPendingBytes()
+          != other.getPendingBytes()) return false;
+      if (!getTraceId()
+          .equals(other.getTraceId())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -4010,74 +4261,76 @@ public final class MessageOuterClass {
       }
       hash = (37 * hash) + PENDINGBYTES_FIELD_NUMBER;
       hash = (53 * hash) + getPendingBytes();
+      hash = (37 * hash) + TRACEID_FIELD_NUMBER;
+      hash = (53 * hash) + getTraceId().hashCode();
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
       return hash;
     }
 
-    public static MessageOuterClass.Message parseFrom(
+    public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message parseFrom(
         java.nio.ByteBuffer data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static MessageOuterClass.Message parseFrom(
+    public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message parseFrom(
         java.nio.ByteBuffer data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static MessageOuterClass.Message parseFrom(
+    public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static MessageOuterClass.Message parseFrom(
+    public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static MessageOuterClass.Message parseFrom(byte[] data)
+    public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static MessageOuterClass.Message parseFrom(
+    public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static MessageOuterClass.Message parseFrom(java.io.InputStream input)
+    public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message parseFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static MessageOuterClass.Message parseFrom(
+    public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
-    public static MessageOuterClass.Message parseDelimitedFrom(java.io.InputStream input)
+    public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
-    public static MessageOuterClass.Message parseDelimitedFrom(
+    public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-    public static MessageOuterClass.Message parseFrom(
+    public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static MessageOuterClass.Message parseFrom(
+    public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
@@ -4090,7 +4343,7 @@ public final class MessageOuterClass {
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-    public static Builder newBuilder(MessageOuterClass.Message prototype) {
+    public static Builder newBuilder(org.peergos.protocol.bitswap.pb.MessageOuterClass.Message prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
     @java.lang.Override
@@ -4106,26 +4359,26 @@ public final class MessageOuterClass {
       return builder;
     }
     /**
-     * Protobuf type {@code bitswap.message.pb.Message}
+     * Protobuf type {@code org.peergos.protocol.bitswap.pb.Message}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:bitswap.message.pb.Message)
-        MessageOuterClass.MessageOrBuilder {
+        // @@protoc_insertion_point(builder_implements:org.peergos.protocol.bitswap.pb.Message)
+        org.peergos.protocol.bitswap.pb.MessageOuterClass.MessageOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return MessageOuterClass.internal_static_bitswap_message_pb_Message_descriptor;
+        return org.peergos.protocol.bitswap.pb.MessageOuterClass.internal_static_bitswap_message_pb_Message_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return MessageOuterClass.internal_static_bitswap_message_pb_Message_fieldAccessorTable
+        return org.peergos.protocol.bitswap.pb.MessageOuterClass.internal_static_bitswap_message_pb_Message_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                MessageOuterClass.Message.class, MessageOuterClass.Message.Builder.class);
+                org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.class, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Builder.class);
       }
 
-      // Construct using bitswap.message.pb.MessageOuterClass.Message.newBuilder()
+      // Construct using org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.newBuilder()
       private Builder() {
         maybeForceBuilderInitialization();
       }
@@ -4152,20 +4405,22 @@ public final class MessageOuterClass {
           wantlistBuilder_ = null;
         }
         blocks_ = java.util.Collections.emptyList();
-        bitField0_ = (bitField0_ & ~0x00000002);
+        bitField0_ = (bitField0_ & ~0x00000001);
         if (payloadBuilder_ == null) {
           payload_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000004);
+          bitField0_ = (bitField0_ & ~0x00000002);
         } else {
           payloadBuilder_.clear();
         }
         if (blockPresencesBuilder_ == null) {
           blockPresences_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000008);
+          bitField0_ = (bitField0_ & ~0x00000004);
         } else {
           blockPresencesBuilder_.clear();
         }
         pendingBytes_ = 0;
+
+        traceId_ = "";
 
         return this;
       }
@@ -4173,17 +4428,17 @@ public final class MessageOuterClass {
       @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return MessageOuterClass.internal_static_bitswap_message_pb_Message_descriptor;
+        return org.peergos.protocol.bitswap.pb.MessageOuterClass.internal_static_bitswap_message_pb_Message_descriptor;
       }
 
       @java.lang.Override
-      public MessageOuterClass.Message getDefaultInstanceForType() {
-        return MessageOuterClass.Message.getDefaultInstance();
+      public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message getDefaultInstanceForType() {
+        return org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.getDefaultInstance();
       }
 
       @java.lang.Override
-      public MessageOuterClass.Message build() {
-        MessageOuterClass.Message result = buildPartial();
+      public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message build() {
+        org.peergos.protocol.bitswap.pb.MessageOuterClass.Message result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
@@ -4191,95 +4446,94 @@ public final class MessageOuterClass {
       }
 
       @java.lang.Override
-      public MessageOuterClass.Message buildPartial() {
-        MessageOuterClass.Message result = new MessageOuterClass.Message(this);
+      public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message buildPartial() {
+        org.peergos.protocol.bitswap.pb.MessageOuterClass.Message result = new org.peergos.protocol.bitswap.pb.MessageOuterClass.Message(this);
         int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
         if (wantlistBuilder_ == null) {
           result.wantlist_ = wantlist_;
         } else {
           result.wantlist_ = wantlistBuilder_.build();
         }
-        if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((bitField0_ & 0x00000001) != 0)) {
           blocks_ = java.util.Collections.unmodifiableList(blocks_);
-          bitField0_ = (bitField0_ & ~0x00000002);
+          bitField0_ = (bitField0_ & ~0x00000001);
         }
         result.blocks_ = blocks_;
         if (payloadBuilder_ == null) {
-          if (((bitField0_ & 0x00000004) == 0x00000004)) {
+          if (((bitField0_ & 0x00000002) != 0)) {
             payload_ = java.util.Collections.unmodifiableList(payload_);
-            bitField0_ = (bitField0_ & ~0x00000004);
+            bitField0_ = (bitField0_ & ~0x00000002);
           }
           result.payload_ = payload_;
         } else {
           result.payload_ = payloadBuilder_.build();
         }
         if (blockPresencesBuilder_ == null) {
-          if (((bitField0_ & 0x00000008) == 0x00000008)) {
+          if (((bitField0_ & 0x00000004) != 0)) {
             blockPresences_ = java.util.Collections.unmodifiableList(blockPresences_);
-            bitField0_ = (bitField0_ & ~0x00000008);
+            bitField0_ = (bitField0_ & ~0x00000004);
           }
           result.blockPresences_ = blockPresences_;
         } else {
           result.blockPresences_ = blockPresencesBuilder_.build();
         }
         result.pendingBytes_ = pendingBytes_;
-        result.bitField0_ = to_bitField0_;
+        result.traceId_ = traceId_;
         onBuilt();
         return result;
       }
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof MessageOuterClass.Message) {
-          return mergeFrom((MessageOuterClass.Message)other);
+        if (other instanceof org.peergos.protocol.bitswap.pb.MessageOuterClass.Message) {
+          return mergeFrom((org.peergos.protocol.bitswap.pb.MessageOuterClass.Message)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(MessageOuterClass.Message other) {
-        if (other == MessageOuterClass.Message.getDefaultInstance()) return this;
+      public Builder mergeFrom(org.peergos.protocol.bitswap.pb.MessageOuterClass.Message other) {
+        if (other == org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.getDefaultInstance()) return this;
         if (other.hasWantlist()) {
           mergeWantlist(other.getWantlist());
         }
         if (!other.blocks_.isEmpty()) {
           if (blocks_.isEmpty()) {
             blocks_ = other.blocks_;
-            bitField0_ = (bitField0_ & ~0x00000002);
+            bitField0_ = (bitField0_ & ~0x00000001);
           } else {
             ensureBlocksIsMutable();
             blocks_.addAll(other.blocks_);
@@ -4290,7 +4544,7 @@ public final class MessageOuterClass {
           if (!other.payload_.isEmpty()) {
             if (payload_.isEmpty()) {
               payload_ = other.payload_;
-              bitField0_ = (bitField0_ & ~0x00000004);
+              bitField0_ = (bitField0_ & ~0x00000002);
             } else {
               ensurePayloadIsMutable();
               payload_.addAll(other.payload_);
@@ -4303,7 +4557,7 @@ public final class MessageOuterClass {
               payloadBuilder_.dispose();
               payloadBuilder_ = null;
               payload_ = other.payload_;
-              bitField0_ = (bitField0_ & ~0x00000004);
+              bitField0_ = (bitField0_ & ~0x00000002);
               payloadBuilder_ = 
                 com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                    getPayloadFieldBuilder() : null;
@@ -4316,7 +4570,7 @@ public final class MessageOuterClass {
           if (!other.blockPresences_.isEmpty()) {
             if (blockPresences_.isEmpty()) {
               blockPresences_ = other.blockPresences_;
-              bitField0_ = (bitField0_ & ~0x00000008);
+              bitField0_ = (bitField0_ & ~0x00000004);
             } else {
               ensureBlockPresencesIsMutable();
               blockPresences_.addAll(other.blockPresences_);
@@ -4329,7 +4583,7 @@ public final class MessageOuterClass {
               blockPresencesBuilder_.dispose();
               blockPresencesBuilder_ = null;
               blockPresences_ = other.blockPresences_;
-              bitField0_ = (bitField0_ & ~0x00000008);
+              bitField0_ = (bitField0_ & ~0x00000004);
               blockPresencesBuilder_ = 
                 com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                    getBlockPresencesFieldBuilder() : null;
@@ -4340,6 +4594,10 @@ public final class MessageOuterClass {
         }
         if (other.getPendingBytes() != 0) {
           setPendingBytes(other.getPendingBytes());
+        }
+        if (!other.getTraceId().isEmpty()) {
+          traceId_ = other.traceId_;
+          onChanged();
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -4356,11 +4614,11 @@ public final class MessageOuterClass {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        MessageOuterClass.Message parsedMessage = null;
+        org.peergos.protocol.bitswap.pb.MessageOuterClass.Message parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (MessageOuterClass.Message) e.getUnfinishedMessage();
+          parsedMessage = (org.peergos.protocol.bitswap.pb.MessageOuterClass.Message) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -4371,15 +4629,16 @@ public final class MessageOuterClass {
       }
       private int bitField0_;
 
-      private MessageOuterClass.Message.Wantlist wantlist_ = null;
+      private org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist wantlist_;
       private com.google.protobuf.SingleFieldBuilderV3<
-          MessageOuterClass.Message.Wantlist, MessageOuterClass.Message.Wantlist.Builder, MessageOuterClass.Message.WantlistOrBuilder> wantlistBuilder_;
+          org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Builder, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.WantlistOrBuilder> wantlistBuilder_;
       /**
        * <pre>
        *[(gogoproto.nullable) = false];
        * </pre>
        *
-       * <code>.bitswap.message.pb.Message.Wantlist wantlist = 1;</code>
+       * <code>.org.peergos.protocol.bitswap.pb.Message.Wantlist wantlist = 1;</code>
+       * @return Whether the wantlist field is set.
        */
       public boolean hasWantlist() {
         return wantlistBuilder_ != null || wantlist_ != null;
@@ -4389,11 +4648,12 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];
        * </pre>
        *
-       * <code>.bitswap.message.pb.Message.Wantlist wantlist = 1;</code>
+       * <code>.org.peergos.protocol.bitswap.pb.Message.Wantlist wantlist = 1;</code>
+       * @return The wantlist.
        */
-      public MessageOuterClass.Message.Wantlist getWantlist() {
+      public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist getWantlist() {
         if (wantlistBuilder_ == null) {
-          return wantlist_ == null ? MessageOuterClass.Message.Wantlist.getDefaultInstance() : wantlist_;
+          return wantlist_ == null ? org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.getDefaultInstance() : wantlist_;
         } else {
           return wantlistBuilder_.getMessage();
         }
@@ -4403,9 +4663,9 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];
        * </pre>
        *
-       * <code>.bitswap.message.pb.Message.Wantlist wantlist = 1;</code>
+       * <code>.org.peergos.protocol.bitswap.pb.Message.Wantlist wantlist = 1;</code>
        */
-      public Builder setWantlist(MessageOuterClass.Message.Wantlist value) {
+      public Builder setWantlist(org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist value) {
         if (wantlistBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -4423,10 +4683,10 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];
        * </pre>
        *
-       * <code>.bitswap.message.pb.Message.Wantlist wantlist = 1;</code>
+       * <code>.org.peergos.protocol.bitswap.pb.Message.Wantlist wantlist = 1;</code>
        */
       public Builder setWantlist(
-          MessageOuterClass.Message.Wantlist.Builder builderForValue) {
+          org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Builder builderForValue) {
         if (wantlistBuilder_ == null) {
           wantlist_ = builderForValue.build();
           onChanged();
@@ -4441,13 +4701,13 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];
        * </pre>
        *
-       * <code>.bitswap.message.pb.Message.Wantlist wantlist = 1;</code>
+       * <code>.org.peergos.protocol.bitswap.pb.Message.Wantlist wantlist = 1;</code>
        */
-      public Builder mergeWantlist(MessageOuterClass.Message.Wantlist value) {
+      public Builder mergeWantlist(org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist value) {
         if (wantlistBuilder_ == null) {
           if (wantlist_ != null) {
             wantlist_ =
-              MessageOuterClass.Message.Wantlist.newBuilder(wantlist_).mergeFrom(value).buildPartial();
+              org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.newBuilder(wantlist_).mergeFrom(value).buildPartial();
           } else {
             wantlist_ = value;
           }
@@ -4463,7 +4723,7 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];
        * </pre>
        *
-       * <code>.bitswap.message.pb.Message.Wantlist wantlist = 1;</code>
+       * <code>.org.peergos.protocol.bitswap.pb.Message.Wantlist wantlist = 1;</code>
        */
       public Builder clearWantlist() {
         if (wantlistBuilder_ == null) {
@@ -4481,9 +4741,9 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];
        * </pre>
        *
-       * <code>.bitswap.message.pb.Message.Wantlist wantlist = 1;</code>
+       * <code>.org.peergos.protocol.bitswap.pb.Message.Wantlist wantlist = 1;</code>
        */
-      public MessageOuterClass.Message.Wantlist.Builder getWantlistBuilder() {
+      public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Builder getWantlistBuilder() {
         
         onChanged();
         return getWantlistFieldBuilder().getBuilder();
@@ -4493,14 +4753,14 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];
        * </pre>
        *
-       * <code>.bitswap.message.pb.Message.Wantlist wantlist = 1;</code>
+       * <code>.org.peergos.protocol.bitswap.pb.Message.Wantlist wantlist = 1;</code>
        */
-      public MessageOuterClass.Message.WantlistOrBuilder getWantlistOrBuilder() {
+      public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.WantlistOrBuilder getWantlistOrBuilder() {
         if (wantlistBuilder_ != null) {
           return wantlistBuilder_.getMessageOrBuilder();
         } else {
           return wantlist_ == null ?
-              MessageOuterClass.Message.Wantlist.getDefaultInstance() : wantlist_;
+              org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.getDefaultInstance() : wantlist_;
         }
       }
       /**
@@ -4508,14 +4768,14 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];
        * </pre>
        *
-       * <code>.bitswap.message.pb.Message.Wantlist wantlist = 1;</code>
+       * <code>.org.peergos.protocol.bitswap.pb.Message.Wantlist wantlist = 1;</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
-          MessageOuterClass.Message.Wantlist, MessageOuterClass.Message.Wantlist.Builder, MessageOuterClass.Message.WantlistOrBuilder>
+          org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Builder, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.WantlistOrBuilder> 
           getWantlistFieldBuilder() {
         if (wantlistBuilder_ == null) {
           wantlistBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-              MessageOuterClass.Message.Wantlist, MessageOuterClass.Message.Wantlist.Builder, MessageOuterClass.Message.WantlistOrBuilder>(
+              org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Wantlist.Builder, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.WantlistOrBuilder>(
                   getWantlist(),
                   getParentForChildren(),
                   isClean());
@@ -4526,9 +4786,9 @@ public final class MessageOuterClass {
 
       private java.util.List<com.google.protobuf.ByteString> blocks_ = java.util.Collections.emptyList();
       private void ensureBlocksIsMutable() {
-        if (!((bitField0_ & 0x00000002) == 0x00000002)) {
+        if (!((bitField0_ & 0x00000001) != 0)) {
           blocks_ = new java.util.ArrayList<com.google.protobuf.ByteString>(blocks_);
-          bitField0_ |= 0x00000002;
+          bitField0_ |= 0x00000001;
          }
       }
       /**
@@ -4537,10 +4797,12 @@ public final class MessageOuterClass {
        * </pre>
        *
        * <code>repeated bytes blocks = 2;</code>
+       * @return A list containing the blocks.
        */
       public java.util.List<com.google.protobuf.ByteString>
           getBlocksList() {
-        return java.util.Collections.unmodifiableList(blocks_);
+        return ((bitField0_ & 0x00000001) != 0) ?
+                 java.util.Collections.unmodifiableList(blocks_) : blocks_;
       }
       /**
        * <pre>
@@ -4548,6 +4810,7 @@ public final class MessageOuterClass {
        * </pre>
        *
        * <code>repeated bytes blocks = 2;</code>
+       * @return The count of blocks.
        */
       public int getBlocksCount() {
         return blocks_.size();
@@ -4558,6 +4821,8 @@ public final class MessageOuterClass {
        * </pre>
        *
        * <code>repeated bytes blocks = 2;</code>
+       * @param index The index of the element to return.
+       * @return The blocks at the given index.
        */
       public com.google.protobuf.ByteString getBlocks(int index) {
         return blocks_.get(index);
@@ -4568,6 +4833,9 @@ public final class MessageOuterClass {
        * </pre>
        *
        * <code>repeated bytes blocks = 2;</code>
+       * @param index The index to set the value at.
+       * @param value The blocks to set.
+       * @return This builder for chaining.
        */
       public Builder setBlocks(
           int index, com.google.protobuf.ByteString value) {
@@ -4585,6 +4853,8 @@ public final class MessageOuterClass {
        * </pre>
        *
        * <code>repeated bytes blocks = 2;</code>
+       * @param value The blocks to add.
+       * @return This builder for chaining.
        */
       public Builder addBlocks(com.google.protobuf.ByteString value) {
         if (value == null) {
@@ -4601,6 +4871,8 @@ public final class MessageOuterClass {
        * </pre>
        *
        * <code>repeated bytes blocks = 2;</code>
+       * @param values The blocks to add.
+       * @return This builder for chaining.
        */
       public Builder addAllBlocks(
           java.lang.Iterable<? extends com.google.protobuf.ByteString> values) {
@@ -4616,34 +4888,35 @@ public final class MessageOuterClass {
        * </pre>
        *
        * <code>repeated bytes blocks = 2;</code>
+       * @return This builder for chaining.
        */
       public Builder clearBlocks() {
         blocks_ = java.util.Collections.emptyList();
-        bitField0_ = (bitField0_ & ~0x00000002);
+        bitField0_ = (bitField0_ & ~0x00000001);
         onChanged();
         return this;
       }
 
-      private java.util.List<MessageOuterClass.Message.Block> payload_ =
+      private java.util.List<org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block> payload_ =
         java.util.Collections.emptyList();
       private void ensurePayloadIsMutable() {
-        if (!((bitField0_ & 0x00000004) == 0x00000004)) {
-          payload_ = new java.util.ArrayList<MessageOuterClass.Message.Block>(payload_);
-          bitField0_ |= 0x00000004;
+        if (!((bitField0_ & 0x00000002) != 0)) {
+          payload_ = new java.util.ArrayList<org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block>(payload_);
+          bitField0_ |= 0x00000002;
          }
       }
 
       private com.google.protobuf.RepeatedFieldBuilderV3<
-          MessageOuterClass.Message.Block, MessageOuterClass.Message.Block.Builder, MessageOuterClass.Message.BlockOrBuilder> payloadBuilder_;
+          org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block.Builder, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockOrBuilder> payloadBuilder_;
 
       /**
        * <pre>
        *[(gogoproto.nullable) = false];		// used to send Blocks in bitswap 1.1.0
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.Block payload = 3;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Block payload = 3;</code>
        */
-      public java.util.List<MessageOuterClass.Message.Block> getPayloadList() {
+      public java.util.List<org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block> getPayloadList() {
         if (payloadBuilder_ == null) {
           return java.util.Collections.unmodifiableList(payload_);
         } else {
@@ -4655,7 +4928,7 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];		// used to send Blocks in bitswap 1.1.0
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.Block payload = 3;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Block payload = 3;</code>
        */
       public int getPayloadCount() {
         if (payloadBuilder_ == null) {
@@ -4669,9 +4942,9 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];		// used to send Blocks in bitswap 1.1.0
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.Block payload = 3;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Block payload = 3;</code>
        */
-      public MessageOuterClass.Message.Block getPayload(int index) {
+      public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block getPayload(int index) {
         if (payloadBuilder_ == null) {
           return payload_.get(index);
         } else {
@@ -4683,10 +4956,10 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];		// used to send Blocks in bitswap 1.1.0
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.Block payload = 3;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Block payload = 3;</code>
        */
       public Builder setPayload(
-          int index, MessageOuterClass.Message.Block value) {
+          int index, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block value) {
         if (payloadBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -4704,10 +4977,10 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];		// used to send Blocks in bitswap 1.1.0
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.Block payload = 3;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Block payload = 3;</code>
        */
       public Builder setPayload(
-          int index, MessageOuterClass.Message.Block.Builder builderForValue) {
+          int index, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block.Builder builderForValue) {
         if (payloadBuilder_ == null) {
           ensurePayloadIsMutable();
           payload_.set(index, builderForValue.build());
@@ -4722,9 +4995,9 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];		// used to send Blocks in bitswap 1.1.0
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.Block payload = 3;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Block payload = 3;</code>
        */
-      public Builder addPayload(MessageOuterClass.Message.Block value) {
+      public Builder addPayload(org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block value) {
         if (payloadBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -4742,10 +5015,10 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];		// used to send Blocks in bitswap 1.1.0
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.Block payload = 3;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Block payload = 3;</code>
        */
       public Builder addPayload(
-          int index, MessageOuterClass.Message.Block value) {
+          int index, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block value) {
         if (payloadBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -4763,10 +5036,10 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];		// used to send Blocks in bitswap 1.1.0
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.Block payload = 3;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Block payload = 3;</code>
        */
       public Builder addPayload(
-          MessageOuterClass.Message.Block.Builder builderForValue) {
+          org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block.Builder builderForValue) {
         if (payloadBuilder_ == null) {
           ensurePayloadIsMutable();
           payload_.add(builderForValue.build());
@@ -4781,10 +5054,10 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];		// used to send Blocks in bitswap 1.1.0
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.Block payload = 3;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Block payload = 3;</code>
        */
       public Builder addPayload(
-          int index, MessageOuterClass.Message.Block.Builder builderForValue) {
+          int index, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block.Builder builderForValue) {
         if (payloadBuilder_ == null) {
           ensurePayloadIsMutable();
           payload_.add(index, builderForValue.build());
@@ -4799,10 +5072,10 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];		// used to send Blocks in bitswap 1.1.0
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.Block payload = 3;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Block payload = 3;</code>
        */
       public Builder addAllPayload(
-          java.lang.Iterable<? extends MessageOuterClass.Message.Block> values) {
+          java.lang.Iterable<? extends org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block> values) {
         if (payloadBuilder_ == null) {
           ensurePayloadIsMutable();
           com.google.protobuf.AbstractMessageLite.Builder.addAll(
@@ -4818,12 +5091,12 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];		// used to send Blocks in bitswap 1.1.0
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.Block payload = 3;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Block payload = 3;</code>
        */
       public Builder clearPayload() {
         if (payloadBuilder_ == null) {
           payload_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000004);
+          bitField0_ = (bitField0_ & ~0x00000002);
           onChanged();
         } else {
           payloadBuilder_.clear();
@@ -4835,7 +5108,7 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];		// used to send Blocks in bitswap 1.1.0
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.Block payload = 3;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Block payload = 3;</code>
        */
       public Builder removePayload(int index) {
         if (payloadBuilder_ == null) {
@@ -4852,9 +5125,9 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];		// used to send Blocks in bitswap 1.1.0
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.Block payload = 3;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Block payload = 3;</code>
        */
-      public MessageOuterClass.Message.Block.Builder getPayloadBuilder(
+      public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block.Builder getPayloadBuilder(
           int index) {
         return getPayloadFieldBuilder().getBuilder(index);
       }
@@ -4863,9 +5136,9 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];		// used to send Blocks in bitswap 1.1.0
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.Block payload = 3;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Block payload = 3;</code>
        */
-      public MessageOuterClass.Message.BlockOrBuilder getPayloadOrBuilder(
+      public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockOrBuilder getPayloadOrBuilder(
           int index) {
         if (payloadBuilder_ == null) {
           return payload_.get(index);  } else {
@@ -4877,9 +5150,9 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];		// used to send Blocks in bitswap 1.1.0
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.Block payload = 3;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Block payload = 3;</code>
        */
-      public java.util.List<? extends MessageOuterClass.Message.BlockOrBuilder>
+      public java.util.List<? extends org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockOrBuilder> 
            getPayloadOrBuilderList() {
         if (payloadBuilder_ != null) {
           return payloadBuilder_.getMessageOrBuilderList();
@@ -4892,43 +5165,43 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];		// used to send Blocks in bitswap 1.1.0
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.Block payload = 3;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Block payload = 3;</code>
        */
-      public MessageOuterClass.Message.Block.Builder addPayloadBuilder() {
+      public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block.Builder addPayloadBuilder() {
         return getPayloadFieldBuilder().addBuilder(
-            MessageOuterClass.Message.Block.getDefaultInstance());
+            org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block.getDefaultInstance());
       }
       /**
        * <pre>
        *[(gogoproto.nullable) = false];		// used to send Blocks in bitswap 1.1.0
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.Block payload = 3;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Block payload = 3;</code>
        */
-      public MessageOuterClass.Message.Block.Builder addPayloadBuilder(
+      public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block.Builder addPayloadBuilder(
           int index) {
         return getPayloadFieldBuilder().addBuilder(
-            index, MessageOuterClass.Message.Block.getDefaultInstance());
+            index, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block.getDefaultInstance());
       }
       /**
        * <pre>
        *[(gogoproto.nullable) = false];		// used to send Blocks in bitswap 1.1.0
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.Block payload = 3;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.Block payload = 3;</code>
        */
-      public java.util.List<MessageOuterClass.Message.Block.Builder>
+      public java.util.List<org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block.Builder> 
            getPayloadBuilderList() {
         return getPayloadFieldBuilder().getBuilderList();
       }
       private com.google.protobuf.RepeatedFieldBuilderV3<
-          MessageOuterClass.Message.Block, MessageOuterClass.Message.Block.Builder, MessageOuterClass.Message.BlockOrBuilder>
+          org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block.Builder, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockOrBuilder> 
           getPayloadFieldBuilder() {
         if (payloadBuilder_ == null) {
           payloadBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              MessageOuterClass.Message.Block, MessageOuterClass.Message.Block.Builder, MessageOuterClass.Message.BlockOrBuilder>(
+              org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.Block.Builder, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockOrBuilder>(
                   payload_,
-                  ((bitField0_ & 0x00000004) == 0x00000004),
+                  ((bitField0_ & 0x00000002) != 0),
                   getParentForChildren(),
                   isClean());
           payload_ = null;
@@ -4936,26 +5209,26 @@ public final class MessageOuterClass {
         return payloadBuilder_;
       }
 
-      private java.util.List<MessageOuterClass.Message.BlockPresence> blockPresences_ =
+      private java.util.List<org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence> blockPresences_ =
         java.util.Collections.emptyList();
       private void ensureBlockPresencesIsMutable() {
-        if (!((bitField0_ & 0x00000008) == 0x00000008)) {
-          blockPresences_ = new java.util.ArrayList<MessageOuterClass.Message.BlockPresence>(blockPresences_);
-          bitField0_ |= 0x00000008;
+        if (!((bitField0_ & 0x00000004) != 0)) {
+          blockPresences_ = new java.util.ArrayList<org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence>(blockPresences_);
+          bitField0_ |= 0x00000004;
          }
       }
 
       private com.google.protobuf.RepeatedFieldBuilderV3<
-          MessageOuterClass.Message.BlockPresence, MessageOuterClass.Message.BlockPresence.Builder, MessageOuterClass.Message.BlockPresenceOrBuilder> blockPresencesBuilder_;
+          org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence.Builder, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresenceOrBuilder> blockPresencesBuilder_;
 
       /**
        * <pre>
        *[(gogoproto.nullable) = false];
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.BlockPresence blockPresences = 4;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.BlockPresence blockPresences = 4;</code>
        */
-      public java.util.List<MessageOuterClass.Message.BlockPresence> getBlockPresencesList() {
+      public java.util.List<org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence> getBlockPresencesList() {
         if (blockPresencesBuilder_ == null) {
           return java.util.Collections.unmodifiableList(blockPresences_);
         } else {
@@ -4967,7 +5240,7 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.BlockPresence blockPresences = 4;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.BlockPresence blockPresences = 4;</code>
        */
       public int getBlockPresencesCount() {
         if (blockPresencesBuilder_ == null) {
@@ -4981,9 +5254,9 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.BlockPresence blockPresences = 4;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.BlockPresence blockPresences = 4;</code>
        */
-      public MessageOuterClass.Message.BlockPresence getBlockPresences(int index) {
+      public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence getBlockPresences(int index) {
         if (blockPresencesBuilder_ == null) {
           return blockPresences_.get(index);
         } else {
@@ -4995,10 +5268,10 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.BlockPresence blockPresences = 4;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.BlockPresence blockPresences = 4;</code>
        */
       public Builder setBlockPresences(
-          int index, MessageOuterClass.Message.BlockPresence value) {
+          int index, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence value) {
         if (blockPresencesBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -5016,10 +5289,10 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.BlockPresence blockPresences = 4;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.BlockPresence blockPresences = 4;</code>
        */
       public Builder setBlockPresences(
-          int index, MessageOuterClass.Message.BlockPresence.Builder builderForValue) {
+          int index, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence.Builder builderForValue) {
         if (blockPresencesBuilder_ == null) {
           ensureBlockPresencesIsMutable();
           blockPresences_.set(index, builderForValue.build());
@@ -5034,9 +5307,9 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.BlockPresence blockPresences = 4;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.BlockPresence blockPresences = 4;</code>
        */
-      public Builder addBlockPresences(MessageOuterClass.Message.BlockPresence value) {
+      public Builder addBlockPresences(org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence value) {
         if (blockPresencesBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -5054,10 +5327,10 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.BlockPresence blockPresences = 4;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.BlockPresence blockPresences = 4;</code>
        */
       public Builder addBlockPresences(
-          int index, MessageOuterClass.Message.BlockPresence value) {
+          int index, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence value) {
         if (blockPresencesBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -5075,10 +5348,10 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.BlockPresence blockPresences = 4;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.BlockPresence blockPresences = 4;</code>
        */
       public Builder addBlockPresences(
-          MessageOuterClass.Message.BlockPresence.Builder builderForValue) {
+          org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence.Builder builderForValue) {
         if (blockPresencesBuilder_ == null) {
           ensureBlockPresencesIsMutable();
           blockPresences_.add(builderForValue.build());
@@ -5093,10 +5366,10 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.BlockPresence blockPresences = 4;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.BlockPresence blockPresences = 4;</code>
        */
       public Builder addBlockPresences(
-          int index, MessageOuterClass.Message.BlockPresence.Builder builderForValue) {
+          int index, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence.Builder builderForValue) {
         if (blockPresencesBuilder_ == null) {
           ensureBlockPresencesIsMutable();
           blockPresences_.add(index, builderForValue.build());
@@ -5111,10 +5384,10 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.BlockPresence blockPresences = 4;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.BlockPresence blockPresences = 4;</code>
        */
       public Builder addAllBlockPresences(
-          java.lang.Iterable<? extends MessageOuterClass.Message.BlockPresence> values) {
+          java.lang.Iterable<? extends org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence> values) {
         if (blockPresencesBuilder_ == null) {
           ensureBlockPresencesIsMutable();
           com.google.protobuf.AbstractMessageLite.Builder.addAll(
@@ -5130,12 +5403,12 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.BlockPresence blockPresences = 4;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.BlockPresence blockPresences = 4;</code>
        */
       public Builder clearBlockPresences() {
         if (blockPresencesBuilder_ == null) {
           blockPresences_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000008);
+          bitField0_ = (bitField0_ & ~0x00000004);
           onChanged();
         } else {
           blockPresencesBuilder_.clear();
@@ -5147,7 +5420,7 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.BlockPresence blockPresences = 4;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.BlockPresence blockPresences = 4;</code>
        */
       public Builder removeBlockPresences(int index) {
         if (blockPresencesBuilder_ == null) {
@@ -5164,9 +5437,9 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.BlockPresence blockPresences = 4;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.BlockPresence blockPresences = 4;</code>
        */
-      public MessageOuterClass.Message.BlockPresence.Builder getBlockPresencesBuilder(
+      public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence.Builder getBlockPresencesBuilder(
           int index) {
         return getBlockPresencesFieldBuilder().getBuilder(index);
       }
@@ -5175,9 +5448,9 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.BlockPresence blockPresences = 4;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.BlockPresence blockPresences = 4;</code>
        */
-      public MessageOuterClass.Message.BlockPresenceOrBuilder getBlockPresencesOrBuilder(
+      public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresenceOrBuilder getBlockPresencesOrBuilder(
           int index) {
         if (blockPresencesBuilder_ == null) {
           return blockPresences_.get(index);  } else {
@@ -5189,9 +5462,9 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.BlockPresence blockPresences = 4;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.BlockPresence blockPresences = 4;</code>
        */
-      public java.util.List<? extends MessageOuterClass.Message.BlockPresenceOrBuilder>
+      public java.util.List<? extends org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresenceOrBuilder> 
            getBlockPresencesOrBuilderList() {
         if (blockPresencesBuilder_ != null) {
           return blockPresencesBuilder_.getMessageOrBuilderList();
@@ -5204,43 +5477,43 @@ public final class MessageOuterClass {
        *[(gogoproto.nullable) = false];
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.BlockPresence blockPresences = 4;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.BlockPresence blockPresences = 4;</code>
        */
-      public MessageOuterClass.Message.BlockPresence.Builder addBlockPresencesBuilder() {
+      public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence.Builder addBlockPresencesBuilder() {
         return getBlockPresencesFieldBuilder().addBuilder(
-            MessageOuterClass.Message.BlockPresence.getDefaultInstance());
+            org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence.getDefaultInstance());
       }
       /**
        * <pre>
        *[(gogoproto.nullable) = false];
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.BlockPresence blockPresences = 4;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.BlockPresence blockPresences = 4;</code>
        */
-      public MessageOuterClass.Message.BlockPresence.Builder addBlockPresencesBuilder(
+      public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence.Builder addBlockPresencesBuilder(
           int index) {
         return getBlockPresencesFieldBuilder().addBuilder(
-            index, MessageOuterClass.Message.BlockPresence.getDefaultInstance());
+            index, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence.getDefaultInstance());
       }
       /**
        * <pre>
        *[(gogoproto.nullable) = false];
        * </pre>
        *
-       * <code>repeated .bitswap.message.pb.Message.BlockPresence blockPresences = 4;</code>
+       * <code>repeated .org.peergos.protocol.bitswap.pb.Message.BlockPresence blockPresences = 4;</code>
        */
-      public java.util.List<MessageOuterClass.Message.BlockPresence.Builder>
+      public java.util.List<org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence.Builder> 
            getBlockPresencesBuilderList() {
         return getBlockPresencesFieldBuilder().getBuilderList();
       }
       private com.google.protobuf.RepeatedFieldBuilderV3<
-          MessageOuterClass.Message.BlockPresence, MessageOuterClass.Message.BlockPresence.Builder, MessageOuterClass.Message.BlockPresenceOrBuilder>
+          org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence.Builder, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresenceOrBuilder> 
           getBlockPresencesFieldBuilder() {
         if (blockPresencesBuilder_ == null) {
           blockPresencesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              MessageOuterClass.Message.BlockPresence, MessageOuterClass.Message.BlockPresence.Builder, MessageOuterClass.Message.BlockPresenceOrBuilder>(
+              org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresence.Builder, org.peergos.protocol.bitswap.pb.MessageOuterClass.Message.BlockPresenceOrBuilder>(
                   blockPresences_,
-                  ((bitField0_ & 0x00000008) == 0x00000008),
+                  ((bitField0_ & 0x00000004) != 0),
                   getParentForChildren(),
                   isClean());
           blockPresences_ = null;
@@ -5251,12 +5524,16 @@ public final class MessageOuterClass {
       private int pendingBytes_ ;
       /**
        * <code>int32 pendingBytes = 5;</code>
+       * @return The pendingBytes.
        */
+      @java.lang.Override
       public int getPendingBytes() {
         return pendingBytes_;
       }
       /**
        * <code>int32 pendingBytes = 5;</code>
+       * @param value The pendingBytes to set.
+       * @return This builder for chaining.
        */
       public Builder setPendingBytes(int value) {
         
@@ -5266,6 +5543,7 @@ public final class MessageOuterClass {
       }
       /**
        * <code>int32 pendingBytes = 5;</code>
+       * @return This builder for chaining.
        */
       public Builder clearPendingBytes() {
         
@@ -5273,10 +5551,86 @@ public final class MessageOuterClass {
         onChanged();
         return this;
       }
+
+      private java.lang.Object traceId_ = "";
+      /**
+       * <code>string traceId = 6;</code>
+       * @return The traceId.
+       */
+      public java.lang.String getTraceId() {
+        java.lang.Object ref = traceId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          traceId_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>string traceId = 6;</code>
+       * @return The bytes for traceId.
+       */
+      public com.google.protobuf.ByteString
+          getTraceIdBytes() {
+        java.lang.Object ref = traceId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          traceId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>string traceId = 6;</code>
+       * @param value The traceId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setTraceId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        traceId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string traceId = 6;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearTraceId() {
+        
+        traceId_ = getDefaultInstance().getTraceId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string traceId = 6;</code>
+       * @param value The bytes for traceId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setTraceIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        traceId_ = value;
+        onChanged();
+        return this;
+      }
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
-        return super.setUnknownFieldsProto3(unknownFields);
+        return super.setUnknownFields(unknownFields);
       }
 
       @java.lang.Override
@@ -5286,16 +5640,16 @@ public final class MessageOuterClass {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:bitswap.message.pb.Message)
+      // @@protoc_insertion_point(builder_scope:org.peergos.protocol.bitswap.pb.Message)
     }
 
-    // @@protoc_insertion_point(class_scope:bitswap.message.pb.Message)
-    private static final MessageOuterClass.Message DEFAULT_INSTANCE;
+    // @@protoc_insertion_point(class_scope:org.peergos.protocol.bitswap.pb.Message)
+    private static final org.peergos.protocol.bitswap.pb.MessageOuterClass.Message DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE = new MessageOuterClass.Message();
+      DEFAULT_INSTANCE = new org.peergos.protocol.bitswap.pb.MessageOuterClass.Message();
     }
 
-    public static MessageOuterClass.Message getDefaultInstance() {
+    public static org.peergos.protocol.bitswap.pb.MessageOuterClass.Message getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
@@ -5320,7 +5674,7 @@ public final class MessageOuterClass {
     }
 
     @java.lang.Override
-    public MessageOuterClass.Message getDefaultInstanceForType() {
+    public org.peergos.protocol.bitswap.pb.MessageOuterClass.Message getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
@@ -5360,44 +5714,37 @@ public final class MessageOuterClass {
       descriptor;
   static {
     java.lang.String[] descriptorData = {
-      "\n\rmessage.proto\022\022bitswap.message.pb\"\302\005\n\007" +
+      "\n\rmessage.proto\022\022org.peergos.protocol.bitswap.pb\"\323\005\n\007" +
       "Message\0226\n\010wantlist\030\001 \001(\0132$.bitswap.mess" +
       "age.pb.Message.Wantlist\022\016\n\006blocks\030\002 \003(\014\022" +
-      "2\n\007payload\030\003 \003(\0132!.bitswap.message.pb.Me" +
+      "2\n\007payload\030\003 \003(\0132!.org.peergos.protocol.bitswap.pb.Me" +
       "ssage.Block\022A\n\016blockPresences\030\004 \003(\0132).bi" +
       "tswap.message.pb.Message.BlockPresence\022\024" +
-      "\n\014pendingBytes\030\005 \001(\005\032\226\002\n\010Wantlist\022;\n\007ent" +
-      "ries\030\001 \003(\0132*.bitswap.message.pb.Message." +
-      "Wantlist.Entry\022\014\n\004full\030\002 \001(\010\032\235\001\n\005Entry\022\r" +
-      "\n\005block\030\001 \001(\014\022\020\n\010priority\030\002 \001(\005\022\016\n\006cance" +
-      "l\030\003 \001(\010\022?\n\010wantType\030\004 \001(\0162-.bitswap.mess" +
-      "age.pb.Message.Wantlist.WantType\022\024\n\014send" +
-      "DontHave\030\005 \001(\010\022\014\n\004auth\030\006 \001(\014\"\037\n\010WantType" +
-      "\022\t\n\005Block\020\000\022\010\n\004Have\020\001\0323\n\005Block\022\016\n\006prefix" +
-      "\030\001 \001(\014\022\014\n\004data\030\002 \001(\014\022\014\n\004auth\030\003 \001(\014\032g\n\rBl" +
-      "ockPresence\022\013\n\003cid\030\001 \001(\014\022;\n\004type\030\002 \001(\0162-" +
-      ".bitswap.message.pb.Message.BlockPresenc" +
-      "eType\022\014\n\004auth\030\003 \001(\014\"+\n\021BlockPresenceType" +
-      "\022\010\n\004Have\020\000\022\014\n\010DontHave\020\001b\006proto3"
+      "\n\014pendingBytes\030\005 \001(\005\022\017\n\007traceId\030\006 \001(\t\032\226\002" +
+      "\n\010Wantlist\022;\n\007entries\030\001 \003(\0132*.bitswap.me" +
+      "ssage.pb.Message.Wantlist.Entry\022\014\n\004full\030" +
+      "\002 \001(\010\032\235\001\n\005Entry\022\r\n\005block\030\001 \001(\014\022\020\n\010priori" +
+      "ty\030\002 \001(\005\022\016\n\006cancel\030\003 \001(\010\022?\n\010wantType\030\004 \001" +
+      "(\0162-.org.peergos.protocol.bitswap.pb.Message.Wantlist" +
+      ".WantType\022\024\n\014sendDontHave\030\005 \001(\010\022\014\n\004auth\030" +
+      "\006 \001(\014\"\037\n\010WantType\022\t\n\005Block\020\000\022\010\n\004Have\020\001\0323" +
+      "\n\005Block\022\016\n\006prefix\030\001 \001(\014\022\014\n\004data\030\002 \001(\014\022\014\n" +
+      "\004auth\030\003 \001(\014\032g\n\rBlockPresence\022\013\n\003cid\030\001 \001(" +
+      "\014\022;\n\004type\030\002 \001(\0162-.org.peergos.protocol.bitswap.pb.Mes" +
+      "sage.BlockPresenceType\022\014\n\004auth\030\003 \001(\014\"+\n\021" +
+      "BlockPresenceType\022\010\n\004Have\020\000\022\014\n\010DontHave\020" +
+      "\001b\006proto3"
     };
-    com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
-        new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
-          public com.google.protobuf.ExtensionRegistry assignDescriptors(
-              com.google.protobuf.Descriptors.FileDescriptor root) {
-            descriptor = root;
-            return null;
-          }
-        };
-    com.google.protobuf.Descriptors.FileDescriptor
+    descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
         new com.google.protobuf.Descriptors.FileDescriptor[] {
-        }, assigner);
+        });
     internal_static_bitswap_message_pb_Message_descriptor =
       getDescriptor().getMessageTypes().get(0);
     internal_static_bitswap_message_pb_Message_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_bitswap_message_pb_Message_descriptor,
-        new java.lang.String[] { "Wantlist", "Blocks", "Payload", "BlockPresences", "PendingBytes", });
+        new java.lang.String[] { "Wantlist", "Blocks", "Payload", "BlockPresences", "PendingBytes", "TraceId", });
     internal_static_bitswap_message_pb_Message_Wantlist_descriptor =
       internal_static_bitswap_message_pb_Message_descriptor.getNestedTypes().get(0);
     internal_static_bitswap_message_pb_Message_Wantlist_fieldAccessorTable = new

--- a/src/main/java/org/peergos/protocol/dht/Kademlia.java
+++ b/src/main/java/org/peergos/protocol/dht/Kademlia.java
@@ -242,8 +242,6 @@ public class Kademlia extends StrictProtocolBinding<KademliaController> implemen
                         KademliaController res = null;
                         try {
                             res = dialPeer(r.addresses, us).join();
-                            System.out.println("Get providers request start for " + block.hashCode() + ". Address: "
-                                    + r.addresses.toString());
                             return res.getProviders(block).orTimeout(2, TimeUnit.SECONDS);
                         } catch (Exception e) {
                             return null;
@@ -254,7 +252,6 @@ public class Kademlia extends StrictProtocolBinding<KademliaController> implemen
             for (CompletableFuture<Providers> future : futures) {
                 try {
                     Providers newProviders = future.join();
-                    System.out.println("Get providers request finished for " + block.hashCode());
                     providers.addAll(newProviders.providers);
                     for (PeerAddresses peer : newProviders.closerPeers) {
                         if (!queried.contains(peer.peerId)) {

--- a/src/main/java/org/peergos/protocol/dht/KademliaEngine.java
+++ b/src/main/java/org/peergos/protocol/dht/KademliaEngine.java
@@ -160,7 +160,6 @@ public class KademliaEngine {
             }
             case GET_PROVIDERS: {
                 Multihash hash = Multihash.deserialize(msg.getKey().toByteArray());
-                System.out.println("Get providers start: " + hash.toString());
                 Set<Dht.Message.Peer> providers = providersStore.getProviders(hash);
                 if (blocks.hasAny(hash).join()) {
                     providers = new HashSet<>(providers);
@@ -180,7 +179,6 @@ public class KademliaEngine {
                         .collect(Collectors.toList()));
                 Dht.Message reply = builder.build();
                 stream.writeAndFlush(reply);
-                System.out.println("Get providers end: " + hash.toString());
                 responderSentBytes.inc(reply.getSerializedSize());
                 responderProvidersSentBytes.inc(reply.getSerializedSize());
                 break;

--- a/src/main/java/org/peergos/protocol/dht/pb/Dht.java
+++ b/src/main/java/org/peergos/protocol/dht/pb/Dht.java
@@ -15,7 +15,7 @@ public final class Dht {
         (com.google.protobuf.ExtensionRegistryLite) registry);
   }
   public interface RecordOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:org.peergos.dht.pb.Record)
+      // @@protoc_insertion_point(interface_extends:org.peergos.protocol.dht.pb.Record)
       com.google.protobuf.MessageOrBuilder {
 
     /**
@@ -24,6 +24,7 @@ public final class Dht {
      * </pre>
      *
      * <code>bytes key = 1;</code>
+     * @return The key.
      */
     com.google.protobuf.ByteString getKey();
 
@@ -33,6 +34,7 @@ public final class Dht {
      * </pre>
      *
      * <code>bytes value = 2;</code>
+     * @return The value.
      */
     com.google.protobuf.ByteString getValue();
 
@@ -42,6 +44,7 @@ public final class Dht {
      * </pre>
      *
      * <code>string timeReceived = 5;</code>
+     * @return The timeReceived.
      */
     java.lang.String getTimeReceived();
     /**
@@ -50,6 +53,7 @@ public final class Dht {
      * </pre>
      *
      * <code>string timeReceived = 5;</code>
+     * @return The bytes for timeReceived.
      */
     com.google.protobuf.ByteString
         getTimeReceivedBytes();
@@ -60,11 +64,11 @@ public final class Dht {
    * for a key value pair
    * </pre>
    *
-   * Protobuf type {@code org.peergos.dht.pb.Record}
+   * Protobuf type {@code org.peergos.protocol.dht.pb.Record}
    */
-  public  static final class Record extends
+  public static final class Record extends
       com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:org.peergos.dht.pb.Record)
+      // @@protoc_insertion_point(message_implements:org.peergos.protocol.dht.pb.Record)
       RecordOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use Record.newBuilder() to construct.
@@ -75,6 +79,13 @@ public final class Dht {
       key_ = com.google.protobuf.ByteString.EMPTY;
       value_ = com.google.protobuf.ByteString.EMPTY;
       timeReceived_ = "";
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new Record();
     }
 
     @java.lang.Override
@@ -90,7 +101,6 @@ public final class Dht {
       if (extensionRegistry == null) {
         throw new java.lang.NullPointerException();
       }
-      int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
       try {
@@ -118,7 +128,7 @@ public final class Dht {
               break;
             }
             default: {
-              if (!parseUnknownFieldProto3(
+              if (!parseUnknownField(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
@@ -138,15 +148,15 @@ public final class Dht {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return Dht.internal_static_org_peergos_dht_pb_Record_descriptor;
+      return org.peergos.protocol.dht.pb.Dht.internal_static_org_peergos_protocol_dht_pb_Record_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return Dht.internal_static_org_peergos_dht_pb_Record_fieldAccessorTable
+      return org.peergos.protocol.dht.pb.Dht.internal_static_org_peergos_protocol_dht_pb_Record_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              Dht.Record.class, Dht.Record.Builder.class);
+              org.peergos.protocol.dht.pb.Dht.Record.class, org.peergos.protocol.dht.pb.Dht.Record.Builder.class);
     }
 
     public static final int KEY_FIELD_NUMBER = 1;
@@ -157,7 +167,9 @@ public final class Dht {
      * </pre>
      *
      * <code>bytes key = 1;</code>
+     * @return The key.
      */
+    @java.lang.Override
     public com.google.protobuf.ByteString getKey() {
       return key_;
     }
@@ -170,7 +182,9 @@ public final class Dht {
      * </pre>
      *
      * <code>bytes value = 2;</code>
+     * @return The value.
      */
+    @java.lang.Override
     public com.google.protobuf.ByteString getValue() {
       return value_;
     }
@@ -183,7 +197,9 @@ public final class Dht {
      * </pre>
      *
      * <code>string timeReceived = 5;</code>
+     * @return The timeReceived.
      */
+    @java.lang.Override
     public java.lang.String getTimeReceived() {
       java.lang.Object ref = timeReceived_;
       if (ref instanceof java.lang.String) {
@@ -202,7 +218,9 @@ public final class Dht {
      * </pre>
      *
      * <code>string timeReceived = 5;</code>
+     * @return The bytes for timeReceived.
      */
+    @java.lang.Override
     public com.google.protobuf.ByteString
         getTimeReceivedBytes() {
       java.lang.Object ref = timeReceived_;
@@ -270,20 +288,19 @@ public final class Dht {
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof Dht.Record)) {
+      if (!(obj instanceof org.peergos.protocol.dht.pb.Dht.Record)) {
         return super.equals(obj);
       }
-      Dht.Record other = (Dht.Record) obj;
+      org.peergos.protocol.dht.pb.Dht.Record other = (org.peergos.protocol.dht.pb.Dht.Record) obj;
 
-      boolean result = true;
-      result = result && getKey()
-          .equals(other.getKey());
-      result = result && getValue()
-          .equals(other.getValue());
-      result = result && getTimeReceived()
-          .equals(other.getTimeReceived());
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!getKey()
+          .equals(other.getKey())) return false;
+      if (!getValue()
+          .equals(other.getValue())) return false;
+      if (!getTimeReceived()
+          .equals(other.getTimeReceived())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -304,69 +321,69 @@ public final class Dht {
       return hash;
     }
 
-    public static Dht.Record parseFrom(
+    public static org.peergos.protocol.dht.pb.Dht.Record parseFrom(
         java.nio.ByteBuffer data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static Dht.Record parseFrom(
+    public static org.peergos.protocol.dht.pb.Dht.Record parseFrom(
         java.nio.ByteBuffer data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static Dht.Record parseFrom(
+    public static org.peergos.protocol.dht.pb.Dht.Record parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static Dht.Record parseFrom(
+    public static org.peergos.protocol.dht.pb.Dht.Record parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static Dht.Record parseFrom(byte[] data)
+    public static org.peergos.protocol.dht.pb.Dht.Record parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static Dht.Record parseFrom(
+    public static org.peergos.protocol.dht.pb.Dht.Record parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static Dht.Record parseFrom(java.io.InputStream input)
+    public static org.peergos.protocol.dht.pb.Dht.Record parseFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static Dht.Record parseFrom(
+    public static org.peergos.protocol.dht.pb.Dht.Record parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
-    public static Dht.Record parseDelimitedFrom(java.io.InputStream input)
+    public static org.peergos.protocol.dht.pb.Dht.Record parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
-    public static Dht.Record parseDelimitedFrom(
+    public static org.peergos.protocol.dht.pb.Dht.Record parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-    public static Dht.Record parseFrom(
+    public static org.peergos.protocol.dht.pb.Dht.Record parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static Dht.Record parseFrom(
+    public static org.peergos.protocol.dht.pb.Dht.Record parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
@@ -379,7 +396,7 @@ public final class Dht {
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-    public static Builder newBuilder(Dht.Record prototype) {
+    public static Builder newBuilder(org.peergos.protocol.dht.pb.Dht.Record prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
     @java.lang.Override
@@ -400,26 +417,26 @@ public final class Dht {
      * for a key value pair
      * </pre>
      *
-     * Protobuf type {@code org.peergos.dht.pb.Record}
+     * Protobuf type {@code org.peergos.protocol.dht.pb.Record}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:org.peergos.dht.pb.Record)
-        Dht.RecordOrBuilder {
+        // @@protoc_insertion_point(builder_implements:org.peergos.protocol.dht.pb.Record)
+        org.peergos.protocol.dht.pb.Dht.RecordOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return Dht.internal_static_org_peergos_dht_pb_Record_descriptor;
+        return org.peergos.protocol.dht.pb.Dht.internal_static_org_peergos_protocol_dht_pb_Record_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return Dht.internal_static_org_peergos_dht_pb_Record_fieldAccessorTable
+        return org.peergos.protocol.dht.pb.Dht.internal_static_org_peergos_protocol_dht_pb_Record_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                Dht.Record.class, Dht.Record.Builder.class);
+                org.peergos.protocol.dht.pb.Dht.Record.class, org.peergos.protocol.dht.pb.Dht.Record.Builder.class);
       }
 
-      // Construct using org.peergos.dht.pb.Dht.Record.newBuilder()
+      // Construct using org.peergos.protocol.dht.pb.Dht.Record.newBuilder()
       private Builder() {
         maybeForceBuilderInitialization();
       }
@@ -449,17 +466,17 @@ public final class Dht {
       @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return Dht.internal_static_org_peergos_dht_pb_Record_descriptor;
+        return org.peergos.protocol.dht.pb.Dht.internal_static_org_peergos_protocol_dht_pb_Record_descriptor;
       }
 
       @java.lang.Override
-      public Dht.Record getDefaultInstanceForType() {
-        return Dht.Record.getDefaultInstance();
+      public org.peergos.protocol.dht.pb.Dht.Record getDefaultInstanceForType() {
+        return org.peergos.protocol.dht.pb.Dht.Record.getDefaultInstance();
       }
 
       @java.lang.Override
-      public Dht.Record build() {
-        Dht.Record result = buildPartial();
+      public org.peergos.protocol.dht.pb.Dht.Record build() {
+        org.peergos.protocol.dht.pb.Dht.Record result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
@@ -467,8 +484,8 @@ public final class Dht {
       }
 
       @java.lang.Override
-      public Dht.Record buildPartial() {
-        Dht.Record result = new Dht.Record(this);
+      public org.peergos.protocol.dht.pb.Dht.Record buildPartial() {
+        org.peergos.protocol.dht.pb.Dht.Record result = new org.peergos.protocol.dht.pb.Dht.Record(this);
         result.key_ = key_;
         result.value_ = value_;
         result.timeReceived_ = timeReceived_;
@@ -478,48 +495,48 @@ public final class Dht {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof Dht.Record) {
-          return mergeFrom((Dht.Record)other);
+        if (other instanceof org.peergos.protocol.dht.pb.Dht.Record) {
+          return mergeFrom((org.peergos.protocol.dht.pb.Dht.Record)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(Dht.Record other) {
-        if (other == Dht.Record.getDefaultInstance()) return this;
+      public Builder mergeFrom(org.peergos.protocol.dht.pb.Dht.Record other) {
+        if (other == org.peergos.protocol.dht.pb.Dht.Record.getDefaultInstance()) return this;
         if (other.getKey() != com.google.protobuf.ByteString.EMPTY) {
           setKey(other.getKey());
         }
@@ -545,11 +562,11 @@ public final class Dht {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        Dht.Record parsedMessage = null;
+        org.peergos.protocol.dht.pb.Dht.Record parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (Dht.Record) e.getUnfinishedMessage();
+          parsedMessage = (org.peergos.protocol.dht.pb.Dht.Record) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -566,7 +583,9 @@ public final class Dht {
        * </pre>
        *
        * <code>bytes key = 1;</code>
+       * @return The key.
        */
+      @java.lang.Override
       public com.google.protobuf.ByteString getKey() {
         return key_;
       }
@@ -576,6 +595,8 @@ public final class Dht {
        * </pre>
        *
        * <code>bytes key = 1;</code>
+       * @param value The key to set.
+       * @return This builder for chaining.
        */
       public Builder setKey(com.google.protobuf.ByteString value) {
         if (value == null) {
@@ -592,6 +613,7 @@ public final class Dht {
        * </pre>
        *
        * <code>bytes key = 1;</code>
+       * @return This builder for chaining.
        */
       public Builder clearKey() {
         
@@ -607,7 +629,9 @@ public final class Dht {
        * </pre>
        *
        * <code>bytes value = 2;</code>
+       * @return The value.
        */
+      @java.lang.Override
       public com.google.protobuf.ByteString getValue() {
         return value_;
       }
@@ -617,6 +641,8 @@ public final class Dht {
        * </pre>
        *
        * <code>bytes value = 2;</code>
+       * @param value The value to set.
+       * @return This builder for chaining.
        */
       public Builder setValue(com.google.protobuf.ByteString value) {
         if (value == null) {
@@ -633,6 +659,7 @@ public final class Dht {
        * </pre>
        *
        * <code>bytes value = 2;</code>
+       * @return This builder for chaining.
        */
       public Builder clearValue() {
         
@@ -648,6 +675,7 @@ public final class Dht {
        * </pre>
        *
        * <code>string timeReceived = 5;</code>
+       * @return The timeReceived.
        */
       public java.lang.String getTimeReceived() {
         java.lang.Object ref = timeReceived_;
@@ -667,6 +695,7 @@ public final class Dht {
        * </pre>
        *
        * <code>string timeReceived = 5;</code>
+       * @return The bytes for timeReceived.
        */
       public com.google.protobuf.ByteString
           getTimeReceivedBytes() {
@@ -687,6 +716,8 @@ public final class Dht {
        * </pre>
        *
        * <code>string timeReceived = 5;</code>
+       * @param value The timeReceived to set.
+       * @return This builder for chaining.
        */
       public Builder setTimeReceived(
           java.lang.String value) {
@@ -704,6 +735,7 @@ public final class Dht {
        * </pre>
        *
        * <code>string timeReceived = 5;</code>
+       * @return This builder for chaining.
        */
       public Builder clearTimeReceived() {
         
@@ -717,6 +749,8 @@ public final class Dht {
        * </pre>
        *
        * <code>string timeReceived = 5;</code>
+       * @param value The bytes for timeReceived to set.
+       * @return This builder for chaining.
        */
       public Builder setTimeReceivedBytes(
           com.google.protobuf.ByteString value) {
@@ -732,7 +766,7 @@ public final class Dht {
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
-        return super.setUnknownFieldsProto3(unknownFields);
+        return super.setUnknownFields(unknownFields);
       }
 
       @java.lang.Override
@@ -742,16 +776,16 @@ public final class Dht {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:org.peergos.dht.pb.Record)
+      // @@protoc_insertion_point(builder_scope:org.peergos.protocol.dht.pb.Record)
     }
 
-    // @@protoc_insertion_point(class_scope:org.peergos.dht.pb.Record)
-    private static final Dht.Record DEFAULT_INSTANCE;
+    // @@protoc_insertion_point(class_scope:org.peergos.protocol.dht.pb.Record)
+    private static final org.peergos.protocol.dht.pb.Dht.Record DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE = new Dht.Record();
+      DEFAULT_INSTANCE = new org.peergos.protocol.dht.pb.Dht.Record();
     }
 
-    public static Dht.Record getDefaultInstance() {
+    public static org.peergos.protocol.dht.pb.Dht.Record getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
@@ -776,14 +810,14 @@ public final class Dht {
     }
 
     @java.lang.Override
-    public Dht.Record getDefaultInstanceForType() {
+    public org.peergos.protocol.dht.pb.Dht.Record getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
   }
 
   public interface MessageOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:org.peergos.dht.pb.Message)
+      // @@protoc_insertion_point(interface_extends:org.peergos.protocol.dht.pb.Message)
       com.google.protobuf.MessageOrBuilder {
 
     /**
@@ -791,7 +825,8 @@ public final class Dht {
      * defines what type of message it is.
      * </pre>
      *
-     * <code>.org.peergos.dht.pb.Message.MessageType type = 1;</code>
+     * <code>.org.peergos.protocol.dht.pb.Message.MessageType type = 1;</code>
+     * @return The enum numeric value on the wire for type.
      */
     int getTypeValue();
     /**
@@ -799,9 +834,10 @@ public final class Dht {
      * defines what type of message it is.
      * </pre>
      *
-     * <code>.org.peergos.dht.pb.Message.MessageType type = 1;</code>
+     * <code>.org.peergos.protocol.dht.pb.Message.MessageType type = 1;</code>
+     * @return The type.
      */
-    Dht.Message.MessageType getType();
+    org.peergos.protocol.dht.pb.Dht.Message.MessageType getType();
 
     /**
      * <pre>
@@ -810,6 +846,7 @@ public final class Dht {
      * </pre>
      *
      * <code>int32 clusterLevelRaw = 10;</code>
+     * @return The clusterLevelRaw.
      */
     int getClusterLevelRaw();
 
@@ -820,6 +857,7 @@ public final class Dht {
      * </pre>
      *
      * <code>bytes key = 2;</code>
+     * @return The key.
      */
     com.google.protobuf.ByteString getKey();
 
@@ -829,7 +867,8 @@ public final class Dht {
      * PUT_VALUE, GET_VALUE
      * </pre>
      *
-     * <code>.org.peergos.dht.pb.Record record = 3;</code>
+     * <code>.org.peergos.protocol.dht.pb.Record record = 3;</code>
+     * @return Whether the record field is set.
      */
     boolean hasRecord();
     /**
@@ -838,18 +877,19 @@ public final class Dht {
      * PUT_VALUE, GET_VALUE
      * </pre>
      *
-     * <code>.org.peergos.dht.pb.Record record = 3;</code>
+     * <code>.org.peergos.protocol.dht.pb.Record record = 3;</code>
+     * @return The record.
      */
-    Dht.Record getRecord();
+    org.peergos.protocol.dht.pb.Dht.Record getRecord();
     /**
      * <pre>
      * Used to return a value
      * PUT_VALUE, GET_VALUE
      * </pre>
      *
-     * <code>.org.peergos.dht.pb.Record record = 3;</code>
+     * <code>.org.peergos.protocol.dht.pb.Record record = 3;</code>
      */
-    Dht.RecordOrBuilder getRecordOrBuilder();
+    org.peergos.protocol.dht.pb.Dht.RecordOrBuilder getRecordOrBuilder();
 
     /**
      * <pre>
@@ -857,9 +897,9 @@ public final class Dht {
      * GET_VALUE, GET_PROVIDERS, FIND_NODE
      * </pre>
      *
-     * <code>repeated .org.peergos.dht.pb.Message.Peer closerPeers = 8;</code>
+     * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer closerPeers = 8;</code>
      */
-    java.util.List<Dht.Message.Peer>
+    java.util.List<org.peergos.protocol.dht.pb.Dht.Message.Peer> 
         getCloserPeersList();
     /**
      * <pre>
@@ -867,16 +907,16 @@ public final class Dht {
      * GET_VALUE, GET_PROVIDERS, FIND_NODE
      * </pre>
      *
-     * <code>repeated .org.peergos.dht.pb.Message.Peer closerPeers = 8;</code>
+     * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer closerPeers = 8;</code>
      */
-    Dht.Message.Peer getCloserPeers(int index);
+    org.peergos.protocol.dht.pb.Dht.Message.Peer getCloserPeers(int index);
     /**
      * <pre>
      * Used to return peers closer to a key in a query
      * GET_VALUE, GET_PROVIDERS, FIND_NODE
      * </pre>
      *
-     * <code>repeated .org.peergos.dht.pb.Message.Peer closerPeers = 8;</code>
+     * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer closerPeers = 8;</code>
      */
     int getCloserPeersCount();
     /**
@@ -885,9 +925,9 @@ public final class Dht {
      * GET_VALUE, GET_PROVIDERS, FIND_NODE
      * </pre>
      *
-     * <code>repeated .org.peergos.dht.pb.Message.Peer closerPeers = 8;</code>
+     * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer closerPeers = 8;</code>
      */
-    java.util.List<? extends Dht.Message.PeerOrBuilder>
+    java.util.List<? extends org.peergos.protocol.dht.pb.Dht.Message.PeerOrBuilder> 
         getCloserPeersOrBuilderList();
     /**
      * <pre>
@@ -895,9 +935,9 @@ public final class Dht {
      * GET_VALUE, GET_PROVIDERS, FIND_NODE
      * </pre>
      *
-     * <code>repeated .org.peergos.dht.pb.Message.Peer closerPeers = 8;</code>
+     * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer closerPeers = 8;</code>
      */
-    Dht.Message.PeerOrBuilder getCloserPeersOrBuilder(
+    org.peergos.protocol.dht.pb.Dht.Message.PeerOrBuilder getCloserPeersOrBuilder(
         int index);
 
     /**
@@ -906,9 +946,9 @@ public final class Dht {
      * GET_VALUE, ADD_PROVIDER, GET_PROVIDERS
      * </pre>
      *
-     * <code>repeated .org.peergos.dht.pb.Message.Peer providerPeers = 9;</code>
+     * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer providerPeers = 9;</code>
      */
-    java.util.List<Dht.Message.Peer>
+    java.util.List<org.peergos.protocol.dht.pb.Dht.Message.Peer> 
         getProviderPeersList();
     /**
      * <pre>
@@ -916,16 +956,16 @@ public final class Dht {
      * GET_VALUE, ADD_PROVIDER, GET_PROVIDERS
      * </pre>
      *
-     * <code>repeated .org.peergos.dht.pb.Message.Peer providerPeers = 9;</code>
+     * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer providerPeers = 9;</code>
      */
-    Dht.Message.Peer getProviderPeers(int index);
+    org.peergos.protocol.dht.pb.Dht.Message.Peer getProviderPeers(int index);
     /**
      * <pre>
      * Used to return Providers
      * GET_VALUE, ADD_PROVIDER, GET_PROVIDERS
      * </pre>
      *
-     * <code>repeated .org.peergos.dht.pb.Message.Peer providerPeers = 9;</code>
+     * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer providerPeers = 9;</code>
      */
     int getProviderPeersCount();
     /**
@@ -934,9 +974,9 @@ public final class Dht {
      * GET_VALUE, ADD_PROVIDER, GET_PROVIDERS
      * </pre>
      *
-     * <code>repeated .org.peergos.dht.pb.Message.Peer providerPeers = 9;</code>
+     * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer providerPeers = 9;</code>
      */
-    java.util.List<? extends Dht.Message.PeerOrBuilder>
+    java.util.List<? extends org.peergos.protocol.dht.pb.Dht.Message.PeerOrBuilder> 
         getProviderPeersOrBuilderList();
     /**
      * <pre>
@@ -944,17 +984,37 @@ public final class Dht {
      * GET_VALUE, ADD_PROVIDER, GET_PROVIDERS
      * </pre>
      *
-     * <code>repeated .org.peergos.dht.pb.Message.Peer providerPeers = 9;</code>
+     * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer providerPeers = 9;</code>
      */
-    Dht.Message.PeerOrBuilder getProviderPeersOrBuilder(
+    org.peergos.protocol.dht.pb.Dht.Message.PeerOrBuilder getProviderPeersOrBuilder(
         int index);
+
+    /**
+     * <pre>
+     * Trace Id.
+     * </pre>
+     *
+     * <code>string traceId = 11;</code>
+     * @return The traceId.
+     */
+    java.lang.String getTraceId();
+    /**
+     * <pre>
+     * Trace Id.
+     * </pre>
+     *
+     * <code>string traceId = 11;</code>
+     * @return The bytes for traceId.
+     */
+    com.google.protobuf.ByteString
+        getTraceIdBytes();
   }
   /**
-   * Protobuf type {@code org.peergos.dht.pb.Message}
+   * Protobuf type {@code org.peergos.protocol.dht.pb.Message}
    */
-  public  static final class Message extends
+  public static final class Message extends
       com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:org.peergos.dht.pb.Message)
+      // @@protoc_insertion_point(message_implements:org.peergos.protocol.dht.pb.Message)
       MessageOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use Message.newBuilder() to construct.
@@ -963,10 +1023,17 @@ public final class Dht {
     }
     private Message() {
       type_ = 0;
-      clusterLevelRaw_ = 0;
       key_ = com.google.protobuf.ByteString.EMPTY;
       closerPeers_ = java.util.Collections.emptyList();
       providerPeers_ = java.util.Collections.emptyList();
+      traceId_ = "";
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new Message();
     }
 
     @java.lang.Override
@@ -1005,11 +1072,11 @@ public final class Dht {
               break;
             }
             case 26: {
-              Dht.Record.Builder subBuilder = null;
+              org.peergos.protocol.dht.pb.Dht.Record.Builder subBuilder = null;
               if (record_ != null) {
                 subBuilder = record_.toBuilder();
               }
-              record_ = input.readMessage(Dht.Record.parser(), extensionRegistry);
+              record_ = input.readMessage(org.peergos.protocol.dht.pb.Dht.Record.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(record_);
                 record_ = subBuilder.buildPartial();
@@ -1018,21 +1085,21 @@ public final class Dht {
               break;
             }
             case 66: {
-              if (!((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
-                closerPeers_ = new java.util.ArrayList<Dht.Message.Peer>();
-                mutable_bitField0_ |= 0x00000010;
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
+                closerPeers_ = new java.util.ArrayList<org.peergos.protocol.dht.pb.Dht.Message.Peer>();
+                mutable_bitField0_ |= 0x00000001;
               }
               closerPeers_.add(
-                  input.readMessage(Dht.Message.Peer.parser(), extensionRegistry));
+                  input.readMessage(org.peergos.protocol.dht.pb.Dht.Message.Peer.parser(), extensionRegistry));
               break;
             }
             case 74: {
-              if (!((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
-                providerPeers_ = new java.util.ArrayList<Dht.Message.Peer>();
-                mutable_bitField0_ |= 0x00000020;
+              if (!((mutable_bitField0_ & 0x00000002) != 0)) {
+                providerPeers_ = new java.util.ArrayList<org.peergos.protocol.dht.pb.Dht.Message.Peer>();
+                mutable_bitField0_ |= 0x00000002;
               }
               providerPeers_.add(
-                  input.readMessage(Dht.Message.Peer.parser(), extensionRegistry));
+                  input.readMessage(org.peergos.protocol.dht.pb.Dht.Message.Peer.parser(), extensionRegistry));
               break;
             }
             case 80: {
@@ -1040,8 +1107,14 @@ public final class Dht {
               clusterLevelRaw_ = input.readInt32();
               break;
             }
+            case 90: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              traceId_ = s;
+              break;
+            }
             default: {
-              if (!parseUnknownFieldProto3(
+              if (!parseUnknownField(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
@@ -1055,10 +1128,10 @@ public final class Dht {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
+        if (((mutable_bitField0_ & 0x00000001) != 0)) {
           closerPeers_ = java.util.Collections.unmodifiableList(closerPeers_);
         }
-        if (((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
+        if (((mutable_bitField0_ & 0x00000002) != 0)) {
           providerPeers_ = java.util.Collections.unmodifiableList(providerPeers_);
         }
         this.unknownFields = unknownFields.build();
@@ -1067,19 +1140,19 @@ public final class Dht {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return Dht.internal_static_org_peergos_dht_pb_Message_descriptor;
+      return org.peergos.protocol.dht.pb.Dht.internal_static_org_peergos_protocol_dht_pb_Message_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return Dht.internal_static_org_peergos_dht_pb_Message_fieldAccessorTable
+      return org.peergos.protocol.dht.pb.Dht.internal_static_org_peergos_protocol_dht_pb_Message_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              Dht.Message.class, Dht.Message.Builder.class);
+              org.peergos.protocol.dht.pb.Dht.Message.class, org.peergos.protocol.dht.pb.Dht.Message.Builder.class);
     }
 
     /**
-     * Protobuf enum {@code org.peergos.dht.pb.Message.MessageType}
+     * Protobuf enum {@code org.peergos.protocol.dht.pb.Message.MessageType}
      */
     public enum MessageType
         implements com.google.protobuf.ProtocolMessageEnum {
@@ -1145,6 +1218,8 @@ public final class Dht {
       }
 
       /**
+       * @param value The numeric wire value of the corresponding enum entry.
+       * @return The enum associated with the given numeric wire value.
        * @deprecated Use {@link #forNumber(int)} instead.
        */
       @java.lang.Deprecated
@@ -1152,6 +1227,10 @@ public final class Dht {
         return forNumber(value);
       }
 
+      /**
+       * @param value The numeric wire value of the corresponding enum entry.
+       * @return The enum associated with the given numeric wire value.
+       */
       public static MessageType forNumber(int value) {
         switch (value) {
           case 0: return PUT_VALUE;
@@ -1178,6 +1257,10 @@ public final class Dht {
 
       public final com.google.protobuf.Descriptors.EnumValueDescriptor
           getValueDescriptor() {
+        if (this == UNRECOGNIZED) {
+          throw new java.lang.IllegalStateException(
+              "Can't get the descriptor of an unrecognized enum value.");
+        }
         return getDescriptor().getValues().get(ordinal());
       }
       public final com.google.protobuf.Descriptors.EnumDescriptor
@@ -1186,7 +1269,7 @@ public final class Dht {
       }
       public static final com.google.protobuf.Descriptors.EnumDescriptor
           getDescriptor() {
-        return Dht.Message.getDescriptor().getEnumTypes().get(0);
+        return org.peergos.protocol.dht.pb.Dht.Message.getDescriptor().getEnumTypes().get(0);
       }
 
       private static final MessageType[] VALUES = values();
@@ -1209,11 +1292,11 @@ public final class Dht {
         this.value = value;
       }
 
-      // @@protoc_insertion_point(enum_scope:org.peergos.dht.pb.Message.MessageType)
+      // @@protoc_insertion_point(enum_scope:org.peergos.protocol.dht.pb.Message.MessageType)
     }
 
     /**
-     * Protobuf enum {@code org.peergos.dht.pb.Message.ConnectionType}
+     * Protobuf enum {@code org.peergos.protocol.dht.pb.Message.ConnectionType}
      */
     public enum ConnectionType
         implements com.google.protobuf.ProtocolMessageEnum {
@@ -1297,6 +1380,8 @@ public final class Dht {
       }
 
       /**
+       * @param value The numeric wire value of the corresponding enum entry.
+       * @return The enum associated with the given numeric wire value.
        * @deprecated Use {@link #forNumber(int)} instead.
        */
       @java.lang.Deprecated
@@ -1304,6 +1389,10 @@ public final class Dht {
         return forNumber(value);
       }
 
+      /**
+       * @param value The numeric wire value of the corresponding enum entry.
+       * @return The enum associated with the given numeric wire value.
+       */
       public static ConnectionType forNumber(int value) {
         switch (value) {
           case 0: return NOT_CONNECTED;
@@ -1328,6 +1417,10 @@ public final class Dht {
 
       public final com.google.protobuf.Descriptors.EnumValueDescriptor
           getValueDescriptor() {
+        if (this == UNRECOGNIZED) {
+          throw new java.lang.IllegalStateException(
+              "Can't get the descriptor of an unrecognized enum value.");
+        }
         return getDescriptor().getValues().get(ordinal());
       }
       public final com.google.protobuf.Descriptors.EnumDescriptor
@@ -1336,7 +1429,7 @@ public final class Dht {
       }
       public static final com.google.protobuf.Descriptors.EnumDescriptor
           getDescriptor() {
-        return Dht.Message.getDescriptor().getEnumTypes().get(1);
+        return org.peergos.protocol.dht.pb.Dht.Message.getDescriptor().getEnumTypes().get(1);
       }
 
       private static final ConnectionType[] VALUES = values();
@@ -1359,11 +1452,11 @@ public final class Dht {
         this.value = value;
       }
 
-      // @@protoc_insertion_point(enum_scope:org.peergos.dht.pb.Message.ConnectionType)
+      // @@protoc_insertion_point(enum_scope:org.peergos.protocol.dht.pb.Message.ConnectionType)
     }
 
     public interface PeerOrBuilder extends
-        // @@protoc_insertion_point(interface_extends:org.peergos.dht.pb.Message.Peer)
+        // @@protoc_insertion_point(interface_extends:org.peergos.protocol.dht.pb.Message.Peer)
         com.google.protobuf.MessageOrBuilder {
 
       /**
@@ -1372,6 +1465,7 @@ public final class Dht {
        * </pre>
        *
        * <code>bytes id = 1;</code>
+       * @return The id.
        */
       com.google.protobuf.ByteString getId();
 
@@ -1381,6 +1475,7 @@ public final class Dht {
        * </pre>
        *
        * <code>repeated bytes addrs = 2;</code>
+       * @return A list containing the addrs.
        */
       java.util.List<com.google.protobuf.ByteString> getAddrsList();
       /**
@@ -1389,6 +1484,7 @@ public final class Dht {
        * </pre>
        *
        * <code>repeated bytes addrs = 2;</code>
+       * @return The count of addrs.
        */
       int getAddrsCount();
       /**
@@ -1397,6 +1493,8 @@ public final class Dht {
        * </pre>
        *
        * <code>repeated bytes addrs = 2;</code>
+       * @param index The index of the element to return.
+       * @return The addrs at the given index.
        */
       com.google.protobuf.ByteString getAddrs(int index);
 
@@ -1405,7 +1503,8 @@ public final class Dht {
        * used to signal the sender's connection capabilities to the peer
        * </pre>
        *
-       * <code>.org.peergos.dht.pb.Message.ConnectionType connection = 3;</code>
+       * <code>.org.peergos.protocol.dht.pb.Message.ConnectionType connection = 3;</code>
+       * @return The enum numeric value on the wire for connection.
        */
       int getConnectionValue();
       /**
@@ -1413,16 +1512,17 @@ public final class Dht {
        * used to signal the sender's connection capabilities to the peer
        * </pre>
        *
-       * <code>.org.peergos.dht.pb.Message.ConnectionType connection = 3;</code>
+       * <code>.org.peergos.protocol.dht.pb.Message.ConnectionType connection = 3;</code>
+       * @return The connection.
        */
-      Dht.Message.ConnectionType getConnection();
+      org.peergos.protocol.dht.pb.Dht.Message.ConnectionType getConnection();
     }
     /**
-     * Protobuf type {@code org.peergos.dht.pb.Message.Peer}
+     * Protobuf type {@code org.peergos.protocol.dht.pb.Message.Peer}
      */
-    public  static final class Peer extends
+    public static final class Peer extends
         com.google.protobuf.GeneratedMessageV3 implements
-        // @@protoc_insertion_point(message_implements:org.peergos.dht.pb.Message.Peer)
+        // @@protoc_insertion_point(message_implements:org.peergos.protocol.dht.pb.Message.Peer)
         PeerOrBuilder {
     private static final long serialVersionUID = 0L;
       // Use Peer.newBuilder() to construct.
@@ -1433,6 +1533,13 @@ public final class Dht {
         id_ = com.google.protobuf.ByteString.EMPTY;
         addrs_ = java.util.Collections.emptyList();
         connection_ = 0;
+      }
+
+      @java.lang.Override
+      @SuppressWarnings({"unused"})
+      protected java.lang.Object newInstance(
+          UnusedPrivateParameter unused) {
+        return new Peer();
       }
 
       @java.lang.Override
@@ -1465,9 +1572,9 @@ public final class Dht {
                 break;
               }
               case 18: {
-                if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+                if (!((mutable_bitField0_ & 0x00000001) != 0)) {
                   addrs_ = new java.util.ArrayList<com.google.protobuf.ByteString>();
-                  mutable_bitField0_ |= 0x00000002;
+                  mutable_bitField0_ |= 0x00000001;
                 }
                 addrs_.add(input.readBytes());
                 break;
@@ -1479,7 +1586,7 @@ public final class Dht {
                 break;
               }
               default: {
-                if (!parseUnknownFieldProto3(
+                if (!parseUnknownField(
                     input, unknownFields, extensionRegistry, tag)) {
                   done = true;
                 }
@@ -1493,8 +1600,8 @@ public final class Dht {
           throw new com.google.protobuf.InvalidProtocolBufferException(
               e).setUnfinishedMessage(this);
         } finally {
-          if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
-            addrs_ = java.util.Collections.unmodifiableList(addrs_);
+          if (((mutable_bitField0_ & 0x00000001) != 0)) {
+            addrs_ = java.util.Collections.unmodifiableList(addrs_); // C
           }
           this.unknownFields = unknownFields.build();
           makeExtensionsImmutable();
@@ -1502,18 +1609,17 @@ public final class Dht {
       }
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return Dht.internal_static_org_peergos_dht_pb_Message_Peer_descriptor;
+        return org.peergos.protocol.dht.pb.Dht.internal_static_org_peergos_protocol_dht_pb_Message_Peer_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return Dht.internal_static_org_peergos_dht_pb_Message_Peer_fieldAccessorTable
+        return org.peergos.protocol.dht.pb.Dht.internal_static_org_peergos_protocol_dht_pb_Message_Peer_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                Dht.Message.Peer.class, Dht.Message.Peer.Builder.class);
+                org.peergos.protocol.dht.pb.Dht.Message.Peer.class, org.peergos.protocol.dht.pb.Dht.Message.Peer.Builder.class);
       }
 
-      private int bitField0_;
       public static final int ID_FIELD_NUMBER = 1;
       private com.google.protobuf.ByteString id_;
       /**
@@ -1522,7 +1628,9 @@ public final class Dht {
        * </pre>
        *
        * <code>bytes id = 1;</code>
+       * @return The id.
        */
+      @java.lang.Override
       public com.google.protobuf.ByteString getId() {
         return id_;
       }
@@ -1535,7 +1643,9 @@ public final class Dht {
        * </pre>
        *
        * <code>repeated bytes addrs = 2;</code>
+       * @return A list containing the addrs.
        */
+      @java.lang.Override
       public java.util.List<com.google.protobuf.ByteString>
           getAddrsList() {
         return addrs_;
@@ -1546,6 +1656,7 @@ public final class Dht {
        * </pre>
        *
        * <code>repeated bytes addrs = 2;</code>
+       * @return The count of addrs.
        */
       public int getAddrsCount() {
         return addrs_.size();
@@ -1556,6 +1667,8 @@ public final class Dht {
        * </pre>
        *
        * <code>repeated bytes addrs = 2;</code>
+       * @param index The index of the element to return.
+       * @return The addrs at the given index.
        */
       public com.google.protobuf.ByteString getAddrs(int index) {
         return addrs_.get(index);
@@ -1568,9 +1681,10 @@ public final class Dht {
        * used to signal the sender's connection capabilities to the peer
        * </pre>
        *
-       * <code>.org.peergos.dht.pb.Message.ConnectionType connection = 3;</code>
+       * <code>.org.peergos.protocol.dht.pb.Message.ConnectionType connection = 3;</code>
+       * @return The enum numeric value on the wire for connection.
        */
-      public int getConnectionValue() {
+      @java.lang.Override public int getConnectionValue() {
         return connection_;
       }
       /**
@@ -1578,12 +1692,13 @@ public final class Dht {
        * used to signal the sender's connection capabilities to the peer
        * </pre>
        *
-       * <code>.org.peergos.dht.pb.Message.ConnectionType connection = 3;</code>
+       * <code>.org.peergos.protocol.dht.pb.Message.ConnectionType connection = 3;</code>
+       * @return The connection.
        */
-      public Dht.Message.ConnectionType getConnection() {
+      @java.lang.Override public org.peergos.protocol.dht.pb.Dht.Message.ConnectionType getConnection() {
         @SuppressWarnings("deprecation")
-        Dht.Message.ConnectionType result = Dht.Message.ConnectionType.valueOf(connection_);
-        return result == null ? Dht.Message.ConnectionType.UNRECOGNIZED : result;
+        org.peergos.protocol.dht.pb.Dht.Message.ConnectionType result = org.peergos.protocol.dht.pb.Dht.Message.ConnectionType.valueOf(connection_);
+        return result == null ? org.peergos.protocol.dht.pb.Dht.Message.ConnectionType.UNRECOGNIZED : result;
       }
 
       private byte memoizedIsInitialized = -1;
@@ -1606,7 +1721,7 @@ public final class Dht {
         for (int i = 0; i < addrs_.size(); i++) {
           output.writeBytes(2, addrs_.get(i));
         }
-        if (connection_ != Dht.Message.ConnectionType.NOT_CONNECTED.getNumber()) {
+        if (connection_ != org.peergos.protocol.dht.pb.Dht.Message.ConnectionType.NOT_CONNECTED.getNumber()) {
           output.writeEnum(3, connection_);
         }
         unknownFields.writeTo(output);
@@ -1631,7 +1746,7 @@ public final class Dht {
           size += dataSize;
           size += 1 * getAddrsList().size();
         }
-        if (connection_ != Dht.Message.ConnectionType.NOT_CONNECTED.getNumber()) {
+        if (connection_ != org.peergos.protocol.dht.pb.Dht.Message.ConnectionType.NOT_CONNECTED.getNumber()) {
           size += com.google.protobuf.CodedOutputStream
             .computeEnumSize(3, connection_);
         }
@@ -1645,19 +1760,18 @@ public final class Dht {
         if (obj == this) {
          return true;
         }
-        if (!(obj instanceof Dht.Message.Peer)) {
+        if (!(obj instanceof org.peergos.protocol.dht.pb.Dht.Message.Peer)) {
           return super.equals(obj);
         }
-        Dht.Message.Peer other = (Dht.Message.Peer) obj;
+        org.peergos.protocol.dht.pb.Dht.Message.Peer other = (org.peergos.protocol.dht.pb.Dht.Message.Peer) obj;
 
-        boolean result = true;
-        result = result && getId()
-            .equals(other.getId());
-        result = result && getAddrsList()
-            .equals(other.getAddrsList());
-        result = result && connection_ == other.connection_;
-        result = result && unknownFields.equals(other.unknownFields);
-        return result;
+        if (!getId()
+            .equals(other.getId())) return false;
+        if (!getAddrsList()
+            .equals(other.getAddrsList())) return false;
+        if (connection_ != other.connection_) return false;
+        if (!unknownFields.equals(other.unknownFields)) return false;
+        return true;
       }
 
       @java.lang.Override
@@ -1680,69 +1794,69 @@ public final class Dht {
         return hash;
       }
 
-      public static Dht.Message.Peer parseFrom(
+      public static org.peergos.protocol.dht.pb.Dht.Message.Peer parseFrom(
           java.nio.ByteBuffer data)
           throws com.google.protobuf.InvalidProtocolBufferException {
         return PARSER.parseFrom(data);
       }
-      public static Dht.Message.Peer parseFrom(
+      public static org.peergos.protocol.dht.pb.Dht.Message.Peer parseFrom(
           java.nio.ByteBuffer data,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
         return PARSER.parseFrom(data, extensionRegistry);
       }
-      public static Dht.Message.Peer parseFrom(
+      public static org.peergos.protocol.dht.pb.Dht.Message.Peer parseFrom(
           com.google.protobuf.ByteString data)
           throws com.google.protobuf.InvalidProtocolBufferException {
         return PARSER.parseFrom(data);
       }
-      public static Dht.Message.Peer parseFrom(
+      public static org.peergos.protocol.dht.pb.Dht.Message.Peer parseFrom(
           com.google.protobuf.ByteString data,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
         return PARSER.parseFrom(data, extensionRegistry);
       }
-      public static Dht.Message.Peer parseFrom(byte[] data)
+      public static org.peergos.protocol.dht.pb.Dht.Message.Peer parseFrom(byte[] data)
           throws com.google.protobuf.InvalidProtocolBufferException {
         return PARSER.parseFrom(data);
       }
-      public static Dht.Message.Peer parseFrom(
+      public static org.peergos.protocol.dht.pb.Dht.Message.Peer parseFrom(
           byte[] data,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
         return PARSER.parseFrom(data, extensionRegistry);
       }
-      public static Dht.Message.Peer parseFrom(java.io.InputStream input)
+      public static org.peergos.protocol.dht.pb.Dht.Message.Peer parseFrom(java.io.InputStream input)
           throws java.io.IOException {
         return com.google.protobuf.GeneratedMessageV3
             .parseWithIOException(PARSER, input);
       }
-      public static Dht.Message.Peer parseFrom(
+      public static org.peergos.protocol.dht.pb.Dht.Message.Peer parseFrom(
           java.io.InputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
         return com.google.protobuf.GeneratedMessageV3
             .parseWithIOException(PARSER, input, extensionRegistry);
       }
-      public static Dht.Message.Peer parseDelimitedFrom(java.io.InputStream input)
+      public static org.peergos.protocol.dht.pb.Dht.Message.Peer parseDelimitedFrom(java.io.InputStream input)
           throws java.io.IOException {
         return com.google.protobuf.GeneratedMessageV3
             .parseDelimitedWithIOException(PARSER, input);
       }
-      public static Dht.Message.Peer parseDelimitedFrom(
+      public static org.peergos.protocol.dht.pb.Dht.Message.Peer parseDelimitedFrom(
           java.io.InputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
         return com.google.protobuf.GeneratedMessageV3
             .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
       }
-      public static Dht.Message.Peer parseFrom(
+      public static org.peergos.protocol.dht.pb.Dht.Message.Peer parseFrom(
           com.google.protobuf.CodedInputStream input)
           throws java.io.IOException {
         return com.google.protobuf.GeneratedMessageV3
             .parseWithIOException(PARSER, input);
       }
-      public static Dht.Message.Peer parseFrom(
+      public static org.peergos.protocol.dht.pb.Dht.Message.Peer parseFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
@@ -1755,7 +1869,7 @@ public final class Dht {
       public static Builder newBuilder() {
         return DEFAULT_INSTANCE.toBuilder();
       }
-      public static Builder newBuilder(Dht.Message.Peer prototype) {
+      public static Builder newBuilder(org.peergos.protocol.dht.pb.Dht.Message.Peer prototype) {
         return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
       }
       @java.lang.Override
@@ -1771,26 +1885,26 @@ public final class Dht {
         return builder;
       }
       /**
-       * Protobuf type {@code org.peergos.dht.pb.Message.Peer}
+       * Protobuf type {@code org.peergos.protocol.dht.pb.Message.Peer}
        */
       public static final class Builder extends
           com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-          // @@protoc_insertion_point(builder_implements:org.peergos.dht.pb.Message.Peer)
-          Dht.Message.PeerOrBuilder {
+          // @@protoc_insertion_point(builder_implements:org.peergos.protocol.dht.pb.Message.Peer)
+          org.peergos.protocol.dht.pb.Dht.Message.PeerOrBuilder {
         public static final com.google.protobuf.Descriptors.Descriptor
             getDescriptor() {
-          return Dht.internal_static_org_peergos_dht_pb_Message_Peer_descriptor;
+          return org.peergos.protocol.dht.pb.Dht.internal_static_org_peergos_protocol_dht_pb_Message_Peer_descriptor;
         }
 
         @java.lang.Override
         protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
             internalGetFieldAccessorTable() {
-          return Dht.internal_static_org_peergos_dht_pb_Message_Peer_fieldAccessorTable
+          return org.peergos.protocol.dht.pb.Dht.internal_static_org_peergos_protocol_dht_pb_Message_Peer_fieldAccessorTable
               .ensureFieldAccessorsInitialized(
-                  Dht.Message.Peer.class, Dht.Message.Peer.Builder.class);
+                  org.peergos.protocol.dht.pb.Dht.Message.Peer.class, org.peergos.protocol.dht.pb.Dht.Message.Peer.Builder.class);
         }
 
-        // Construct using org.peergos.dht.pb.Dht.Message.Peer.newBuilder()
+        // Construct using org.peergos.protocol.dht.pb.Dht.Message.Peer.newBuilder()
         private Builder() {
           maybeForceBuilderInitialization();
         }
@@ -1811,7 +1925,7 @@ public final class Dht {
           id_ = com.google.protobuf.ByteString.EMPTY;
 
           addrs_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000002);
+          bitField0_ = (bitField0_ & ~0x00000001);
           connection_ = 0;
 
           return this;
@@ -1820,17 +1934,17 @@ public final class Dht {
         @java.lang.Override
         public com.google.protobuf.Descriptors.Descriptor
             getDescriptorForType() {
-          return Dht.internal_static_org_peergos_dht_pb_Message_Peer_descriptor;
+          return org.peergos.protocol.dht.pb.Dht.internal_static_org_peergos_protocol_dht_pb_Message_Peer_descriptor;
         }
 
         @java.lang.Override
-        public Dht.Message.Peer getDefaultInstanceForType() {
-          return Dht.Message.Peer.getDefaultInstance();
+        public org.peergos.protocol.dht.pb.Dht.Message.Peer getDefaultInstanceForType() {
+          return org.peergos.protocol.dht.pb.Dht.Message.Peer.getDefaultInstance();
         }
 
         @java.lang.Override
-        public Dht.Message.Peer build() {
-          Dht.Message.Peer result = buildPartial();
+        public org.peergos.protocol.dht.pb.Dht.Message.Peer build() {
+          org.peergos.protocol.dht.pb.Dht.Message.Peer result = buildPartial();
           if (!result.isInitialized()) {
             throw newUninitializedMessageException(result);
           }
@@ -1838,73 +1952,71 @@ public final class Dht {
         }
 
         @java.lang.Override
-        public Dht.Message.Peer buildPartial() {
-          Dht.Message.Peer result = new Dht.Message.Peer(this);
+        public org.peergos.protocol.dht.pb.Dht.Message.Peer buildPartial() {
+          org.peergos.protocol.dht.pb.Dht.Message.Peer result = new org.peergos.protocol.dht.pb.Dht.Message.Peer(this);
           int from_bitField0_ = bitField0_;
-          int to_bitField0_ = 0;
           result.id_ = id_;
-          if (((bitField0_ & 0x00000002) == 0x00000002)) {
+          if (((bitField0_ & 0x00000001) != 0)) {
             addrs_ = java.util.Collections.unmodifiableList(addrs_);
-            bitField0_ = (bitField0_ & ~0x00000002);
+            bitField0_ = (bitField0_ & ~0x00000001);
           }
           result.addrs_ = addrs_;
           result.connection_ = connection_;
-          result.bitField0_ = to_bitField0_;
           onBuilt();
           return result;
         }
 
         @java.lang.Override
         public Builder clone() {
-          return (Builder) super.clone();
+          return super.clone();
         }
         @java.lang.Override
         public Builder setField(
             com.google.protobuf.Descriptors.FieldDescriptor field,
             java.lang.Object value) {
-          return (Builder) super.setField(field, value);
+          return super.setField(field, value);
         }
         @java.lang.Override
         public Builder clearField(
             com.google.protobuf.Descriptors.FieldDescriptor field) {
-          return (Builder) super.clearField(field);
+          return super.clearField(field);
         }
         @java.lang.Override
         public Builder clearOneof(
             com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-          return (Builder) super.clearOneof(oneof);
+          return super.clearOneof(oneof);
         }
         @java.lang.Override
         public Builder setRepeatedField(
             com.google.protobuf.Descriptors.FieldDescriptor field,
             int index, java.lang.Object value) {
-          return (Builder) super.setRepeatedField(field, index, value);
+          return super.setRepeatedField(field, index, value);
         }
         @java.lang.Override
         public Builder addRepeatedField(
             com.google.protobuf.Descriptors.FieldDescriptor field,
             java.lang.Object value) {
-          return (Builder) super.addRepeatedField(field, value);
+          return super.addRepeatedField(field, value);
         }
         @java.lang.Override
         public Builder mergeFrom(com.google.protobuf.Message other) {
-          if (other instanceof Dht.Message.Peer) {
-            return mergeFrom((Dht.Message.Peer)other);
+          if (other instanceof org.peergos.protocol.dht.pb.Dht.Message.Peer) {
+            return mergeFrom((org.peergos.protocol.dht.pb.Dht.Message.Peer)other);
           } else {
             super.mergeFrom(other);
             return this;
           }
         }
 
-        public Builder mergeFrom(Dht.Message.Peer other) {
-          if (other == Dht.Message.Peer.getDefaultInstance()) return this;
+        public Builder mergeFrom(org.peergos.protocol.dht.pb.Dht.Message.Peer other) {
+          if (other == org.peergos.protocol.dht.pb.Dht.Message.Peer.getDefaultInstance()) return this;
           if (other.getId() != com.google.protobuf.ByteString.EMPTY) {
             setId(other.getId());
           }
           if (!other.addrs_.isEmpty()) {
             if (addrs_.isEmpty()) {
               addrs_ = other.addrs_;
-              bitField0_ = (bitField0_ & ~0x00000002);
+              bitField0_ = (bitField0_ & ~0x00000001);
             } else {
               ensureAddrsIsMutable();
               addrs_.addAll(other.addrs_);
@@ -1929,11 +2041,11 @@ public final class Dht {
             com.google.protobuf.CodedInputStream input,
             com.google.protobuf.ExtensionRegistryLite extensionRegistry)
             throws java.io.IOException {
-          Dht.Message.Peer parsedMessage = null;
+          org.peergos.protocol.dht.pb.Dht.Message.Peer parsedMessage = null;
           try {
             parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
           } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-            parsedMessage = (Dht.Message.Peer) e.getUnfinishedMessage();
+            parsedMessage = (org.peergos.protocol.dht.pb.Dht.Message.Peer) e.getUnfinishedMessage();
             throw e.unwrapIOException();
           } finally {
             if (parsedMessage != null) {
@@ -1951,7 +2063,9 @@ public final class Dht {
          * </pre>
          *
          * <code>bytes id = 1;</code>
+         * @return The id.
          */
+        @java.lang.Override
         public com.google.protobuf.ByteString getId() {
           return id_;
         }
@@ -1961,6 +2075,8 @@ public final class Dht {
          * </pre>
          *
          * <code>bytes id = 1;</code>
+         * @param value The id to set.
+         * @return This builder for chaining.
          */
         public Builder setId(com.google.protobuf.ByteString value) {
           if (value == null) {
@@ -1977,6 +2093,7 @@ public final class Dht {
          * </pre>
          *
          * <code>bytes id = 1;</code>
+         * @return This builder for chaining.
          */
         public Builder clearId() {
           
@@ -1987,9 +2104,9 @@ public final class Dht {
 
         private java.util.List<com.google.protobuf.ByteString> addrs_ = java.util.Collections.emptyList();
         private void ensureAddrsIsMutable() {
-          if (!((bitField0_ & 0x00000002) == 0x00000002)) {
+          if (!((bitField0_ & 0x00000001) != 0)) {
             addrs_ = new java.util.ArrayList<com.google.protobuf.ByteString>(addrs_);
-            bitField0_ |= 0x00000002;
+            bitField0_ |= 0x00000001;
            }
         }
         /**
@@ -1998,10 +2115,12 @@ public final class Dht {
          * </pre>
          *
          * <code>repeated bytes addrs = 2;</code>
+         * @return A list containing the addrs.
          */
         public java.util.List<com.google.protobuf.ByteString>
             getAddrsList() {
-          return java.util.Collections.unmodifiableList(addrs_);
+          return ((bitField0_ & 0x00000001) != 0) ?
+                   java.util.Collections.unmodifiableList(addrs_) : addrs_;
         }
         /**
          * <pre>
@@ -2009,6 +2128,7 @@ public final class Dht {
          * </pre>
          *
          * <code>repeated bytes addrs = 2;</code>
+         * @return The count of addrs.
          */
         public int getAddrsCount() {
           return addrs_.size();
@@ -2019,6 +2139,8 @@ public final class Dht {
          * </pre>
          *
          * <code>repeated bytes addrs = 2;</code>
+         * @param index The index of the element to return.
+         * @return The addrs at the given index.
          */
         public com.google.protobuf.ByteString getAddrs(int index) {
           return addrs_.get(index);
@@ -2029,6 +2151,9 @@ public final class Dht {
          * </pre>
          *
          * <code>repeated bytes addrs = 2;</code>
+         * @param index The index to set the value at.
+         * @param value The addrs to set.
+         * @return This builder for chaining.
          */
         public Builder setAddrs(
             int index, com.google.protobuf.ByteString value) {
@@ -2046,6 +2171,8 @@ public final class Dht {
          * </pre>
          *
          * <code>repeated bytes addrs = 2;</code>
+         * @param value The addrs to add.
+         * @return This builder for chaining.
          */
         public Builder addAddrs(com.google.protobuf.ByteString value) {
           if (value == null) {
@@ -2062,6 +2189,8 @@ public final class Dht {
          * </pre>
          *
          * <code>repeated bytes addrs = 2;</code>
+         * @param values The addrs to add.
+         * @return This builder for chaining.
          */
         public Builder addAllAddrs(
             java.lang.Iterable<? extends com.google.protobuf.ByteString> values) {
@@ -2077,10 +2206,11 @@ public final class Dht {
          * </pre>
          *
          * <code>repeated bytes addrs = 2;</code>
+         * @return This builder for chaining.
          */
         public Builder clearAddrs() {
           addrs_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000002);
+          bitField0_ = (bitField0_ & ~0x00000001);
           onChanged();
           return this;
         }
@@ -2091,9 +2221,10 @@ public final class Dht {
          * used to signal the sender's connection capabilities to the peer
          * </pre>
          *
-         * <code>.org.peergos.dht.pb.Message.ConnectionType connection = 3;</code>
+         * <code>.org.peergos.protocol.dht.pb.Message.ConnectionType connection = 3;</code>
+         * @return The enum numeric value on the wire for connection.
          */
-        public int getConnectionValue() {
+        @java.lang.Override public int getConnectionValue() {
           return connection_;
         }
         /**
@@ -2101,9 +2232,12 @@ public final class Dht {
          * used to signal the sender's connection capabilities to the peer
          * </pre>
          *
-         * <code>.org.peergos.dht.pb.Message.ConnectionType connection = 3;</code>
+         * <code>.org.peergos.protocol.dht.pb.Message.ConnectionType connection = 3;</code>
+         * @param value The enum numeric value on the wire for connection to set.
+         * @return This builder for chaining.
          */
         public Builder setConnectionValue(int value) {
+          
           connection_ = value;
           onChanged();
           return this;
@@ -2113,21 +2247,25 @@ public final class Dht {
          * used to signal the sender's connection capabilities to the peer
          * </pre>
          *
-         * <code>.org.peergos.dht.pb.Message.ConnectionType connection = 3;</code>
+         * <code>.org.peergos.protocol.dht.pb.Message.ConnectionType connection = 3;</code>
+         * @return The connection.
          */
-        public Dht.Message.ConnectionType getConnection() {
+        @java.lang.Override
+        public org.peergos.protocol.dht.pb.Dht.Message.ConnectionType getConnection() {
           @SuppressWarnings("deprecation")
-          Dht.Message.ConnectionType result = Dht.Message.ConnectionType.valueOf(connection_);
-          return result == null ? Dht.Message.ConnectionType.UNRECOGNIZED : result;
+          org.peergos.protocol.dht.pb.Dht.Message.ConnectionType result = org.peergos.protocol.dht.pb.Dht.Message.ConnectionType.valueOf(connection_);
+          return result == null ? org.peergos.protocol.dht.pb.Dht.Message.ConnectionType.UNRECOGNIZED : result;
         }
         /**
          * <pre>
          * used to signal the sender's connection capabilities to the peer
          * </pre>
          *
-         * <code>.org.peergos.dht.pb.Message.ConnectionType connection = 3;</code>
+         * <code>.org.peergos.protocol.dht.pb.Message.ConnectionType connection = 3;</code>
+         * @param value The connection to set.
+         * @return This builder for chaining.
          */
-        public Builder setConnection(Dht.Message.ConnectionType value) {
+        public Builder setConnection(org.peergos.protocol.dht.pb.Dht.Message.ConnectionType value) {
           if (value == null) {
             throw new NullPointerException();
           }
@@ -2141,7 +2279,8 @@ public final class Dht {
          * used to signal the sender's connection capabilities to the peer
          * </pre>
          *
-         * <code>.org.peergos.dht.pb.Message.ConnectionType connection = 3;</code>
+         * <code>.org.peergos.protocol.dht.pb.Message.ConnectionType connection = 3;</code>
+         * @return This builder for chaining.
          */
         public Builder clearConnection() {
           
@@ -2152,7 +2291,7 @@ public final class Dht {
         @java.lang.Override
         public final Builder setUnknownFields(
             final com.google.protobuf.UnknownFieldSet unknownFields) {
-          return super.setUnknownFieldsProto3(unknownFields);
+          return super.setUnknownFields(unknownFields);
         }
 
         @java.lang.Override
@@ -2162,16 +2301,16 @@ public final class Dht {
         }
 
 
-        // @@protoc_insertion_point(builder_scope:org.peergos.dht.pb.Message.Peer)
+        // @@protoc_insertion_point(builder_scope:org.peergos.protocol.dht.pb.Message.Peer)
       }
 
-      // @@protoc_insertion_point(class_scope:org.peergos.dht.pb.Message.Peer)
-      private static final Dht.Message.Peer DEFAULT_INSTANCE;
+      // @@protoc_insertion_point(class_scope:org.peergos.protocol.dht.pb.Message.Peer)
+      private static final org.peergos.protocol.dht.pb.Dht.Message.Peer DEFAULT_INSTANCE;
       static {
-        DEFAULT_INSTANCE = new Dht.Message.Peer();
+        DEFAULT_INSTANCE = new org.peergos.protocol.dht.pb.Dht.Message.Peer();
       }
 
-      public static Dht.Message.Peer getDefaultInstance() {
+      public static org.peergos.protocol.dht.pb.Dht.Message.Peer getDefaultInstance() {
         return DEFAULT_INSTANCE;
       }
 
@@ -2196,13 +2335,12 @@ public final class Dht {
       }
 
       @java.lang.Override
-      public Dht.Message.Peer getDefaultInstanceForType() {
+      public org.peergos.protocol.dht.pb.Dht.Message.Peer getDefaultInstanceForType() {
         return DEFAULT_INSTANCE;
       }
 
     }
 
-    private int bitField0_;
     public static final int TYPE_FIELD_NUMBER = 1;
     private int type_;
     /**
@@ -2210,9 +2348,10 @@ public final class Dht {
      * defines what type of message it is.
      * </pre>
      *
-     * <code>.org.peergos.dht.pb.Message.MessageType type = 1;</code>
+     * <code>.org.peergos.protocol.dht.pb.Message.MessageType type = 1;</code>
+     * @return The enum numeric value on the wire for type.
      */
-    public int getTypeValue() {
+    @java.lang.Override public int getTypeValue() {
       return type_;
     }
     /**
@@ -2220,12 +2359,13 @@ public final class Dht {
      * defines what type of message it is.
      * </pre>
      *
-     * <code>.org.peergos.dht.pb.Message.MessageType type = 1;</code>
+     * <code>.org.peergos.protocol.dht.pb.Message.MessageType type = 1;</code>
+     * @return The type.
      */
-    public Dht.Message.MessageType getType() {
+    @java.lang.Override public org.peergos.protocol.dht.pb.Dht.Message.MessageType getType() {
       @SuppressWarnings("deprecation")
-      Dht.Message.MessageType result = Dht.Message.MessageType.valueOf(type_);
-      return result == null ? Dht.Message.MessageType.UNRECOGNIZED : result;
+      org.peergos.protocol.dht.pb.Dht.Message.MessageType result = org.peergos.protocol.dht.pb.Dht.Message.MessageType.valueOf(type_);
+      return result == null ? org.peergos.protocol.dht.pb.Dht.Message.MessageType.UNRECOGNIZED : result;
     }
 
     public static final int CLUSTERLEVELRAW_FIELD_NUMBER = 10;
@@ -2237,7 +2377,9 @@ public final class Dht {
      * </pre>
      *
      * <code>int32 clusterLevelRaw = 10;</code>
+     * @return The clusterLevelRaw.
      */
+    @java.lang.Override
     public int getClusterLevelRaw() {
       return clusterLevelRaw_;
     }
@@ -2251,21 +2393,25 @@ public final class Dht {
      * </pre>
      *
      * <code>bytes key = 2;</code>
+     * @return The key.
      */
+    @java.lang.Override
     public com.google.protobuf.ByteString getKey() {
       return key_;
     }
 
     public static final int RECORD_FIELD_NUMBER = 3;
-    private Dht.Record record_;
+    private org.peergos.protocol.dht.pb.Dht.Record record_;
     /**
      * <pre>
      * Used to return a value
      * PUT_VALUE, GET_VALUE
      * </pre>
      *
-     * <code>.org.peergos.dht.pb.Record record = 3;</code>
+     * <code>.org.peergos.protocol.dht.pb.Record record = 3;</code>
+     * @return Whether the record field is set.
      */
+    @java.lang.Override
     public boolean hasRecord() {
       return record_ != null;
     }
@@ -2275,10 +2421,12 @@ public final class Dht {
      * PUT_VALUE, GET_VALUE
      * </pre>
      *
-     * <code>.org.peergos.dht.pb.Record record = 3;</code>
+     * <code>.org.peergos.protocol.dht.pb.Record record = 3;</code>
+     * @return The record.
      */
-    public Dht.Record getRecord() {
-      return record_ == null ? Dht.Record.getDefaultInstance() : record_;
+    @java.lang.Override
+    public org.peergos.protocol.dht.pb.Dht.Record getRecord() {
+      return record_ == null ? org.peergos.protocol.dht.pb.Dht.Record.getDefaultInstance() : record_;
     }
     /**
      * <pre>
@@ -2286,23 +2434,25 @@ public final class Dht {
      * PUT_VALUE, GET_VALUE
      * </pre>
      *
-     * <code>.org.peergos.dht.pb.Record record = 3;</code>
+     * <code>.org.peergos.protocol.dht.pb.Record record = 3;</code>
      */
-    public Dht.RecordOrBuilder getRecordOrBuilder() {
+    @java.lang.Override
+    public org.peergos.protocol.dht.pb.Dht.RecordOrBuilder getRecordOrBuilder() {
       return getRecord();
     }
 
     public static final int CLOSERPEERS_FIELD_NUMBER = 8;
-    private java.util.List<Dht.Message.Peer> closerPeers_;
+    private java.util.List<org.peergos.protocol.dht.pb.Dht.Message.Peer> closerPeers_;
     /**
      * <pre>
      * Used to return peers closer to a key in a query
      * GET_VALUE, GET_PROVIDERS, FIND_NODE
      * </pre>
      *
-     * <code>repeated .org.peergos.dht.pb.Message.Peer closerPeers = 8;</code>
+     * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer closerPeers = 8;</code>
      */
-    public java.util.List<Dht.Message.Peer> getCloserPeersList() {
+    @java.lang.Override
+    public java.util.List<org.peergos.protocol.dht.pb.Dht.Message.Peer> getCloserPeersList() {
       return closerPeers_;
     }
     /**
@@ -2311,9 +2461,10 @@ public final class Dht {
      * GET_VALUE, GET_PROVIDERS, FIND_NODE
      * </pre>
      *
-     * <code>repeated .org.peergos.dht.pb.Message.Peer closerPeers = 8;</code>
+     * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer closerPeers = 8;</code>
      */
-    public java.util.List<? extends Dht.Message.PeerOrBuilder>
+    @java.lang.Override
+    public java.util.List<? extends org.peergos.protocol.dht.pb.Dht.Message.PeerOrBuilder> 
         getCloserPeersOrBuilderList() {
       return closerPeers_;
     }
@@ -2323,8 +2474,9 @@ public final class Dht {
      * GET_VALUE, GET_PROVIDERS, FIND_NODE
      * </pre>
      *
-     * <code>repeated .org.peergos.dht.pb.Message.Peer closerPeers = 8;</code>
+     * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer closerPeers = 8;</code>
      */
+    @java.lang.Override
     public int getCloserPeersCount() {
       return closerPeers_.size();
     }
@@ -2334,9 +2486,10 @@ public final class Dht {
      * GET_VALUE, GET_PROVIDERS, FIND_NODE
      * </pre>
      *
-     * <code>repeated .org.peergos.dht.pb.Message.Peer closerPeers = 8;</code>
+     * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer closerPeers = 8;</code>
      */
-    public Dht.Message.Peer getCloserPeers(int index) {
+    @java.lang.Override
+    public org.peergos.protocol.dht.pb.Dht.Message.Peer getCloserPeers(int index) {
       return closerPeers_.get(index);
     }
     /**
@@ -2345,24 +2498,26 @@ public final class Dht {
      * GET_VALUE, GET_PROVIDERS, FIND_NODE
      * </pre>
      *
-     * <code>repeated .org.peergos.dht.pb.Message.Peer closerPeers = 8;</code>
+     * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer closerPeers = 8;</code>
      */
-    public Dht.Message.PeerOrBuilder getCloserPeersOrBuilder(
+    @java.lang.Override
+    public org.peergos.protocol.dht.pb.Dht.Message.PeerOrBuilder getCloserPeersOrBuilder(
         int index) {
       return closerPeers_.get(index);
     }
 
     public static final int PROVIDERPEERS_FIELD_NUMBER = 9;
-    private java.util.List<Dht.Message.Peer> providerPeers_;
+    private java.util.List<org.peergos.protocol.dht.pb.Dht.Message.Peer> providerPeers_;
     /**
      * <pre>
      * Used to return Providers
      * GET_VALUE, ADD_PROVIDER, GET_PROVIDERS
      * </pre>
      *
-     * <code>repeated .org.peergos.dht.pb.Message.Peer providerPeers = 9;</code>
+     * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer providerPeers = 9;</code>
      */
-    public java.util.List<Dht.Message.Peer> getProviderPeersList() {
+    @java.lang.Override
+    public java.util.List<org.peergos.protocol.dht.pb.Dht.Message.Peer> getProviderPeersList() {
       return providerPeers_;
     }
     /**
@@ -2371,9 +2526,10 @@ public final class Dht {
      * GET_VALUE, ADD_PROVIDER, GET_PROVIDERS
      * </pre>
      *
-     * <code>repeated .org.peergos.dht.pb.Message.Peer providerPeers = 9;</code>
+     * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer providerPeers = 9;</code>
      */
-    public java.util.List<? extends Dht.Message.PeerOrBuilder>
+    @java.lang.Override
+    public java.util.List<? extends org.peergos.protocol.dht.pb.Dht.Message.PeerOrBuilder> 
         getProviderPeersOrBuilderList() {
       return providerPeers_;
     }
@@ -2383,8 +2539,9 @@ public final class Dht {
      * GET_VALUE, ADD_PROVIDER, GET_PROVIDERS
      * </pre>
      *
-     * <code>repeated .org.peergos.dht.pb.Message.Peer providerPeers = 9;</code>
+     * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer providerPeers = 9;</code>
      */
+    @java.lang.Override
     public int getProviderPeersCount() {
       return providerPeers_.size();
     }
@@ -2394,9 +2551,10 @@ public final class Dht {
      * GET_VALUE, ADD_PROVIDER, GET_PROVIDERS
      * </pre>
      *
-     * <code>repeated .org.peergos.dht.pb.Message.Peer providerPeers = 9;</code>
+     * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer providerPeers = 9;</code>
      */
-    public Dht.Message.Peer getProviderPeers(int index) {
+    @java.lang.Override
+    public org.peergos.protocol.dht.pb.Dht.Message.Peer getProviderPeers(int index) {
       return providerPeers_.get(index);
     }
     /**
@@ -2405,11 +2563,58 @@ public final class Dht {
      * GET_VALUE, ADD_PROVIDER, GET_PROVIDERS
      * </pre>
      *
-     * <code>repeated .org.peergos.dht.pb.Message.Peer providerPeers = 9;</code>
+     * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer providerPeers = 9;</code>
      */
-    public Dht.Message.PeerOrBuilder getProviderPeersOrBuilder(
+    @java.lang.Override
+    public org.peergos.protocol.dht.pb.Dht.Message.PeerOrBuilder getProviderPeersOrBuilder(
         int index) {
       return providerPeers_.get(index);
+    }
+
+    public static final int TRACEID_FIELD_NUMBER = 11;
+    private volatile java.lang.Object traceId_;
+    /**
+     * <pre>
+     * Trace Id.
+     * </pre>
+     *
+     * <code>string traceId = 11;</code>
+     * @return The traceId.
+     */
+    @java.lang.Override
+    public java.lang.String getTraceId() {
+      java.lang.Object ref = traceId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        traceId_ = s;
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * Trace Id.
+     * </pre>
+     *
+     * <code>string traceId = 11;</code>
+     * @return The bytes for traceId.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getTraceIdBytes() {
+      java.lang.Object ref = traceId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        traceId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
     }
 
     private byte memoizedIsInitialized = -1;
@@ -2426,7 +2631,7 @@ public final class Dht {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (type_ != Dht.Message.MessageType.PUT_VALUE.getNumber()) {
+      if (type_ != org.peergos.protocol.dht.pb.Dht.Message.MessageType.PUT_VALUE.getNumber()) {
         output.writeEnum(1, type_);
       }
       if (!key_.isEmpty()) {
@@ -2444,6 +2649,9 @@ public final class Dht {
       if (clusterLevelRaw_ != 0) {
         output.writeInt32(10, clusterLevelRaw_);
       }
+      if (!getTraceIdBytes().isEmpty()) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 11, traceId_);
+      }
       unknownFields.writeTo(output);
     }
 
@@ -2453,7 +2661,7 @@ public final class Dht {
       if (size != -1) return size;
 
       size = 0;
-      if (type_ != Dht.Message.MessageType.PUT_VALUE.getNumber()) {
+      if (type_ != org.peergos.protocol.dht.pb.Dht.Message.MessageType.PUT_VALUE.getNumber()) {
         size += com.google.protobuf.CodedOutputStream
           .computeEnumSize(1, type_);
       }
@@ -2477,6 +2685,9 @@ public final class Dht {
         size += com.google.protobuf.CodedOutputStream
           .computeInt32Size(10, clusterLevelRaw_);
       }
+      if (!getTraceIdBytes().isEmpty()) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(11, traceId_);
+      }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
       return size;
@@ -2487,28 +2698,29 @@ public final class Dht {
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof Dht.Message)) {
+      if (!(obj instanceof org.peergos.protocol.dht.pb.Dht.Message)) {
         return super.equals(obj);
       }
-      Dht.Message other = (Dht.Message) obj;
+      org.peergos.protocol.dht.pb.Dht.Message other = (org.peergos.protocol.dht.pb.Dht.Message) obj;
 
-      boolean result = true;
-      result = result && type_ == other.type_;
-      result = result && (getClusterLevelRaw()
-          == other.getClusterLevelRaw());
-      result = result && getKey()
-          .equals(other.getKey());
-      result = result && (hasRecord() == other.hasRecord());
+      if (type_ != other.type_) return false;
+      if (getClusterLevelRaw()
+          != other.getClusterLevelRaw()) return false;
+      if (!getKey()
+          .equals(other.getKey())) return false;
+      if (hasRecord() != other.hasRecord()) return false;
       if (hasRecord()) {
-        result = result && getRecord()
-            .equals(other.getRecord());
+        if (!getRecord()
+            .equals(other.getRecord())) return false;
       }
-      result = result && getCloserPeersList()
-          .equals(other.getCloserPeersList());
-      result = result && getProviderPeersList()
-          .equals(other.getProviderPeersList());
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!getCloserPeersList()
+          .equals(other.getCloserPeersList())) return false;
+      if (!getProviderPeersList()
+          .equals(other.getProviderPeersList())) return false;
+      if (!getTraceId()
+          .equals(other.getTraceId())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -2536,74 +2748,76 @@ public final class Dht {
         hash = (37 * hash) + PROVIDERPEERS_FIELD_NUMBER;
         hash = (53 * hash) + getProviderPeersList().hashCode();
       }
+      hash = (37 * hash) + TRACEID_FIELD_NUMBER;
+      hash = (53 * hash) + getTraceId().hashCode();
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
       return hash;
     }
 
-    public static Dht.Message parseFrom(
+    public static org.peergos.protocol.dht.pb.Dht.Message parseFrom(
         java.nio.ByteBuffer data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static Dht.Message parseFrom(
+    public static org.peergos.protocol.dht.pb.Dht.Message parseFrom(
         java.nio.ByteBuffer data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static Dht.Message parseFrom(
+    public static org.peergos.protocol.dht.pb.Dht.Message parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static Dht.Message parseFrom(
+    public static org.peergos.protocol.dht.pb.Dht.Message parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static Dht.Message parseFrom(byte[] data)
+    public static org.peergos.protocol.dht.pb.Dht.Message parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static Dht.Message parseFrom(
+    public static org.peergos.protocol.dht.pb.Dht.Message parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static Dht.Message parseFrom(java.io.InputStream input)
+    public static org.peergos.protocol.dht.pb.Dht.Message parseFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static Dht.Message parseFrom(
+    public static org.peergos.protocol.dht.pb.Dht.Message parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
-    public static Dht.Message parseDelimitedFrom(java.io.InputStream input)
+    public static org.peergos.protocol.dht.pb.Dht.Message parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
-    public static Dht.Message parseDelimitedFrom(
+    public static org.peergos.protocol.dht.pb.Dht.Message parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-    public static Dht.Message parseFrom(
+    public static org.peergos.protocol.dht.pb.Dht.Message parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static Dht.Message parseFrom(
+    public static org.peergos.protocol.dht.pb.Dht.Message parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
@@ -2616,7 +2830,7 @@ public final class Dht {
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-    public static Builder newBuilder(Dht.Message prototype) {
+    public static Builder newBuilder(org.peergos.protocol.dht.pb.Dht.Message prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
     @java.lang.Override
@@ -2632,26 +2846,26 @@ public final class Dht {
       return builder;
     }
     /**
-     * Protobuf type {@code org.peergos.dht.pb.Message}
+     * Protobuf type {@code org.peergos.protocol.dht.pb.Message}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:org.peergos.dht.pb.Message)
-        Dht.MessageOrBuilder {
+        // @@protoc_insertion_point(builder_implements:org.peergos.protocol.dht.pb.Message)
+        org.peergos.protocol.dht.pb.Dht.MessageOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return Dht.internal_static_org_peergos_dht_pb_Message_descriptor;
+        return org.peergos.protocol.dht.pb.Dht.internal_static_org_peergos_protocol_dht_pb_Message_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return Dht.internal_static_org_peergos_dht_pb_Message_fieldAccessorTable
+        return org.peergos.protocol.dht.pb.Dht.internal_static_org_peergos_protocol_dht_pb_Message_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                Dht.Message.class, Dht.Message.Builder.class);
+                org.peergos.protocol.dht.pb.Dht.Message.class, org.peergos.protocol.dht.pb.Dht.Message.Builder.class);
       }
 
-      // Construct using org.peergos.dht.pb.Dht.Message.newBuilder()
+      // Construct using org.peergos.protocol.dht.pb.Dht.Message.newBuilder()
       private Builder() {
         maybeForceBuilderInitialization();
       }
@@ -2685,33 +2899,35 @@ public final class Dht {
         }
         if (closerPeersBuilder_ == null) {
           closerPeers_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000010);
+          bitField0_ = (bitField0_ & ~0x00000001);
         } else {
           closerPeersBuilder_.clear();
         }
         if (providerPeersBuilder_ == null) {
           providerPeers_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000020);
+          bitField0_ = (bitField0_ & ~0x00000002);
         } else {
           providerPeersBuilder_.clear();
         }
+        traceId_ = "";
+
         return this;
       }
 
       @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return Dht.internal_static_org_peergos_dht_pb_Message_descriptor;
+        return org.peergos.protocol.dht.pb.Dht.internal_static_org_peergos_protocol_dht_pb_Message_descriptor;
       }
 
       @java.lang.Override
-      public Dht.Message getDefaultInstanceForType() {
-        return Dht.Message.getDefaultInstance();
+      public org.peergos.protocol.dht.pb.Dht.Message getDefaultInstanceForType() {
+        return org.peergos.protocol.dht.pb.Dht.Message.getDefaultInstance();
       }
 
       @java.lang.Override
-      public Dht.Message build() {
-        Dht.Message result = buildPartial();
+      public org.peergos.protocol.dht.pb.Dht.Message build() {
+        org.peergos.protocol.dht.pb.Dht.Message result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
@@ -2719,10 +2935,9 @@ public final class Dht {
       }
 
       @java.lang.Override
-      public Dht.Message buildPartial() {
-        Dht.Message result = new Dht.Message(this);
+      public org.peergos.protocol.dht.pb.Dht.Message buildPartial() {
+        org.peergos.protocol.dht.pb.Dht.Message result = new org.peergos.protocol.dht.pb.Dht.Message(this);
         int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
         result.type_ = type_;
         result.clusterLevelRaw_ = clusterLevelRaw_;
         result.key_ = key_;
@@ -2732,72 +2947,72 @@ public final class Dht {
           result.record_ = recordBuilder_.build();
         }
         if (closerPeersBuilder_ == null) {
-          if (((bitField0_ & 0x00000010) == 0x00000010)) {
+          if (((bitField0_ & 0x00000001) != 0)) {
             closerPeers_ = java.util.Collections.unmodifiableList(closerPeers_);
-            bitField0_ = (bitField0_ & ~0x00000010);
+            bitField0_ = (bitField0_ & ~0x00000001);
           }
           result.closerPeers_ = closerPeers_;
         } else {
           result.closerPeers_ = closerPeersBuilder_.build();
         }
         if (providerPeersBuilder_ == null) {
-          if (((bitField0_ & 0x00000020) == 0x00000020)) {
+          if (((bitField0_ & 0x00000002) != 0)) {
             providerPeers_ = java.util.Collections.unmodifiableList(providerPeers_);
-            bitField0_ = (bitField0_ & ~0x00000020);
+            bitField0_ = (bitField0_ & ~0x00000002);
           }
           result.providerPeers_ = providerPeers_;
         } else {
           result.providerPeers_ = providerPeersBuilder_.build();
         }
-        result.bitField0_ = to_bitField0_;
+        result.traceId_ = traceId_;
         onBuilt();
         return result;
       }
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof Dht.Message) {
-          return mergeFrom((Dht.Message)other);
+        if (other instanceof org.peergos.protocol.dht.pb.Dht.Message) {
+          return mergeFrom((org.peergos.protocol.dht.pb.Dht.Message)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(Dht.Message other) {
-        if (other == Dht.Message.getDefaultInstance()) return this;
+      public Builder mergeFrom(org.peergos.protocol.dht.pb.Dht.Message other) {
+        if (other == org.peergos.protocol.dht.pb.Dht.Message.getDefaultInstance()) return this;
         if (other.type_ != 0) {
           setTypeValue(other.getTypeValue());
         }
@@ -2814,7 +3029,7 @@ public final class Dht {
           if (!other.closerPeers_.isEmpty()) {
             if (closerPeers_.isEmpty()) {
               closerPeers_ = other.closerPeers_;
-              bitField0_ = (bitField0_ & ~0x00000010);
+              bitField0_ = (bitField0_ & ~0x00000001);
             } else {
               ensureCloserPeersIsMutable();
               closerPeers_.addAll(other.closerPeers_);
@@ -2827,7 +3042,7 @@ public final class Dht {
               closerPeersBuilder_.dispose();
               closerPeersBuilder_ = null;
               closerPeers_ = other.closerPeers_;
-              bitField0_ = (bitField0_ & ~0x00000010);
+              bitField0_ = (bitField0_ & ~0x00000001);
               closerPeersBuilder_ = 
                 com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                    getCloserPeersFieldBuilder() : null;
@@ -2840,7 +3055,7 @@ public final class Dht {
           if (!other.providerPeers_.isEmpty()) {
             if (providerPeers_.isEmpty()) {
               providerPeers_ = other.providerPeers_;
-              bitField0_ = (bitField0_ & ~0x00000020);
+              bitField0_ = (bitField0_ & ~0x00000002);
             } else {
               ensureProviderPeersIsMutable();
               providerPeers_.addAll(other.providerPeers_);
@@ -2853,7 +3068,7 @@ public final class Dht {
               providerPeersBuilder_.dispose();
               providerPeersBuilder_ = null;
               providerPeers_ = other.providerPeers_;
-              bitField0_ = (bitField0_ & ~0x00000020);
+              bitField0_ = (bitField0_ & ~0x00000002);
               providerPeersBuilder_ = 
                 com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                    getProviderPeersFieldBuilder() : null;
@@ -2861,6 +3076,10 @@ public final class Dht {
               providerPeersBuilder_.addAllMessages(other.providerPeers_);
             }
           }
+        }
+        if (!other.getTraceId().isEmpty()) {
+          traceId_ = other.traceId_;
+          onChanged();
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -2877,11 +3096,11 @@ public final class Dht {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        Dht.Message parsedMessage = null;
+        org.peergos.protocol.dht.pb.Dht.Message parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (Dht.Message) e.getUnfinishedMessage();
+          parsedMessage = (org.peergos.protocol.dht.pb.Dht.Message) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -2898,9 +3117,10 @@ public final class Dht {
        * defines what type of message it is.
        * </pre>
        *
-       * <code>.org.peergos.dht.pb.Message.MessageType type = 1;</code>
+       * <code>.org.peergos.protocol.dht.pb.Message.MessageType type = 1;</code>
+       * @return The enum numeric value on the wire for type.
        */
-      public int getTypeValue() {
+      @java.lang.Override public int getTypeValue() {
         return type_;
       }
       /**
@@ -2908,9 +3128,12 @@ public final class Dht {
        * defines what type of message it is.
        * </pre>
        *
-       * <code>.org.peergos.dht.pb.Message.MessageType type = 1;</code>
+       * <code>.org.peergos.protocol.dht.pb.Message.MessageType type = 1;</code>
+       * @param value The enum numeric value on the wire for type to set.
+       * @return This builder for chaining.
        */
       public Builder setTypeValue(int value) {
+        
         type_ = value;
         onChanged();
         return this;
@@ -2920,21 +3143,25 @@ public final class Dht {
        * defines what type of message it is.
        * </pre>
        *
-       * <code>.org.peergos.dht.pb.Message.MessageType type = 1;</code>
+       * <code>.org.peergos.protocol.dht.pb.Message.MessageType type = 1;</code>
+       * @return The type.
        */
-      public Dht.Message.MessageType getType() {
+      @java.lang.Override
+      public org.peergos.protocol.dht.pb.Dht.Message.MessageType getType() {
         @SuppressWarnings("deprecation")
-        Dht.Message.MessageType result = Dht.Message.MessageType.valueOf(type_);
-        return result == null ? Dht.Message.MessageType.UNRECOGNIZED : result;
+        org.peergos.protocol.dht.pb.Dht.Message.MessageType result = org.peergos.protocol.dht.pb.Dht.Message.MessageType.valueOf(type_);
+        return result == null ? org.peergos.protocol.dht.pb.Dht.Message.MessageType.UNRECOGNIZED : result;
       }
       /**
        * <pre>
        * defines what type of message it is.
        * </pre>
        *
-       * <code>.org.peergos.dht.pb.Message.MessageType type = 1;</code>
+       * <code>.org.peergos.protocol.dht.pb.Message.MessageType type = 1;</code>
+       * @param value The type to set.
+       * @return This builder for chaining.
        */
-      public Builder setType(Dht.Message.MessageType value) {
+      public Builder setType(org.peergos.protocol.dht.pb.Dht.Message.MessageType value) {
         if (value == null) {
           throw new NullPointerException();
         }
@@ -2948,7 +3175,8 @@ public final class Dht {
        * defines what type of message it is.
        * </pre>
        *
-       * <code>.org.peergos.dht.pb.Message.MessageType type = 1;</code>
+       * <code>.org.peergos.protocol.dht.pb.Message.MessageType type = 1;</code>
+       * @return This builder for chaining.
        */
       public Builder clearType() {
         
@@ -2965,7 +3193,9 @@ public final class Dht {
        * </pre>
        *
        * <code>int32 clusterLevelRaw = 10;</code>
+       * @return The clusterLevelRaw.
        */
+      @java.lang.Override
       public int getClusterLevelRaw() {
         return clusterLevelRaw_;
       }
@@ -2976,6 +3206,8 @@ public final class Dht {
        * </pre>
        *
        * <code>int32 clusterLevelRaw = 10;</code>
+       * @param value The clusterLevelRaw to set.
+       * @return This builder for chaining.
        */
       public Builder setClusterLevelRaw(int value) {
         
@@ -2990,6 +3222,7 @@ public final class Dht {
        * </pre>
        *
        * <code>int32 clusterLevelRaw = 10;</code>
+       * @return This builder for chaining.
        */
       public Builder clearClusterLevelRaw() {
         
@@ -3006,7 +3239,9 @@ public final class Dht {
        * </pre>
        *
        * <code>bytes key = 2;</code>
+       * @return The key.
        */
+      @java.lang.Override
       public com.google.protobuf.ByteString getKey() {
         return key_;
       }
@@ -3017,6 +3252,8 @@ public final class Dht {
        * </pre>
        *
        * <code>bytes key = 2;</code>
+       * @param value The key to set.
+       * @return This builder for chaining.
        */
       public Builder setKey(com.google.protobuf.ByteString value) {
         if (value == null) {
@@ -3034,6 +3271,7 @@ public final class Dht {
        * </pre>
        *
        * <code>bytes key = 2;</code>
+       * @return This builder for chaining.
        */
       public Builder clearKey() {
         
@@ -3042,16 +3280,17 @@ public final class Dht {
         return this;
       }
 
-      private Dht.Record record_ = null;
+      private org.peergos.protocol.dht.pb.Dht.Record record_;
       private com.google.protobuf.SingleFieldBuilderV3<
-          Dht.Record, Dht.Record.Builder, Dht.RecordOrBuilder> recordBuilder_;
+          org.peergos.protocol.dht.pb.Dht.Record, org.peergos.protocol.dht.pb.Dht.Record.Builder, org.peergos.protocol.dht.pb.Dht.RecordOrBuilder> recordBuilder_;
       /**
        * <pre>
        * Used to return a value
        * PUT_VALUE, GET_VALUE
        * </pre>
        *
-       * <code>.org.peergos.dht.pb.Record record = 3;</code>
+       * <code>.org.peergos.protocol.dht.pb.Record record = 3;</code>
+       * @return Whether the record field is set.
        */
       public boolean hasRecord() {
         return recordBuilder_ != null || record_ != null;
@@ -3062,11 +3301,12 @@ public final class Dht {
        * PUT_VALUE, GET_VALUE
        * </pre>
        *
-       * <code>.org.peergos.dht.pb.Record record = 3;</code>
+       * <code>.org.peergos.protocol.dht.pb.Record record = 3;</code>
+       * @return The record.
        */
-      public Dht.Record getRecord() {
+      public org.peergos.protocol.dht.pb.Dht.Record getRecord() {
         if (recordBuilder_ == null) {
-          return record_ == null ? Dht.Record.getDefaultInstance() : record_;
+          return record_ == null ? org.peergos.protocol.dht.pb.Dht.Record.getDefaultInstance() : record_;
         } else {
           return recordBuilder_.getMessage();
         }
@@ -3077,9 +3317,9 @@ public final class Dht {
        * PUT_VALUE, GET_VALUE
        * </pre>
        *
-       * <code>.org.peergos.dht.pb.Record record = 3;</code>
+       * <code>.org.peergos.protocol.dht.pb.Record record = 3;</code>
        */
-      public Builder setRecord(Dht.Record value) {
+      public Builder setRecord(org.peergos.protocol.dht.pb.Dht.Record value) {
         if (recordBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -3098,10 +3338,10 @@ public final class Dht {
        * PUT_VALUE, GET_VALUE
        * </pre>
        *
-       * <code>.org.peergos.dht.pb.Record record = 3;</code>
+       * <code>.org.peergos.protocol.dht.pb.Record record = 3;</code>
        */
       public Builder setRecord(
-          Dht.Record.Builder builderForValue) {
+          org.peergos.protocol.dht.pb.Dht.Record.Builder builderForValue) {
         if (recordBuilder_ == null) {
           record_ = builderForValue.build();
           onChanged();
@@ -3117,13 +3357,13 @@ public final class Dht {
        * PUT_VALUE, GET_VALUE
        * </pre>
        *
-       * <code>.org.peergos.dht.pb.Record record = 3;</code>
+       * <code>.org.peergos.protocol.dht.pb.Record record = 3;</code>
        */
-      public Builder mergeRecord(Dht.Record value) {
+      public Builder mergeRecord(org.peergos.protocol.dht.pb.Dht.Record value) {
         if (recordBuilder_ == null) {
           if (record_ != null) {
             record_ =
-              Dht.Record.newBuilder(record_).mergeFrom(value).buildPartial();
+              org.peergos.protocol.dht.pb.Dht.Record.newBuilder(record_).mergeFrom(value).buildPartial();
           } else {
             record_ = value;
           }
@@ -3140,7 +3380,7 @@ public final class Dht {
        * PUT_VALUE, GET_VALUE
        * </pre>
        *
-       * <code>.org.peergos.dht.pb.Record record = 3;</code>
+       * <code>.org.peergos.protocol.dht.pb.Record record = 3;</code>
        */
       public Builder clearRecord() {
         if (recordBuilder_ == null) {
@@ -3159,9 +3399,9 @@ public final class Dht {
        * PUT_VALUE, GET_VALUE
        * </pre>
        *
-       * <code>.org.peergos.dht.pb.Record record = 3;</code>
+       * <code>.org.peergos.protocol.dht.pb.Record record = 3;</code>
        */
-      public Dht.Record.Builder getRecordBuilder() {
+      public org.peergos.protocol.dht.pb.Dht.Record.Builder getRecordBuilder() {
         
         onChanged();
         return getRecordFieldBuilder().getBuilder();
@@ -3172,14 +3412,14 @@ public final class Dht {
        * PUT_VALUE, GET_VALUE
        * </pre>
        *
-       * <code>.org.peergos.dht.pb.Record record = 3;</code>
+       * <code>.org.peergos.protocol.dht.pb.Record record = 3;</code>
        */
-      public Dht.RecordOrBuilder getRecordOrBuilder() {
+      public org.peergos.protocol.dht.pb.Dht.RecordOrBuilder getRecordOrBuilder() {
         if (recordBuilder_ != null) {
           return recordBuilder_.getMessageOrBuilder();
         } else {
           return record_ == null ?
-              Dht.Record.getDefaultInstance() : record_;
+              org.peergos.protocol.dht.pb.Dht.Record.getDefaultInstance() : record_;
         }
       }
       /**
@@ -3188,14 +3428,14 @@ public final class Dht {
        * PUT_VALUE, GET_VALUE
        * </pre>
        *
-       * <code>.org.peergos.dht.pb.Record record = 3;</code>
+       * <code>.org.peergos.protocol.dht.pb.Record record = 3;</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
-          Dht.Record, Dht.Record.Builder, Dht.RecordOrBuilder>
+          org.peergos.protocol.dht.pb.Dht.Record, org.peergos.protocol.dht.pb.Dht.Record.Builder, org.peergos.protocol.dht.pb.Dht.RecordOrBuilder> 
           getRecordFieldBuilder() {
         if (recordBuilder_ == null) {
           recordBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-              Dht.Record, Dht.Record.Builder, Dht.RecordOrBuilder>(
+              org.peergos.protocol.dht.pb.Dht.Record, org.peergos.protocol.dht.pb.Dht.Record.Builder, org.peergos.protocol.dht.pb.Dht.RecordOrBuilder>(
                   getRecord(),
                   getParentForChildren(),
                   isClean());
@@ -3204,17 +3444,17 @@ public final class Dht {
         return recordBuilder_;
       }
 
-      private java.util.List<Dht.Message.Peer> closerPeers_ =
+      private java.util.List<org.peergos.protocol.dht.pb.Dht.Message.Peer> closerPeers_ =
         java.util.Collections.emptyList();
       private void ensureCloserPeersIsMutable() {
-        if (!((bitField0_ & 0x00000010) == 0x00000010)) {
-          closerPeers_ = new java.util.ArrayList<Dht.Message.Peer>(closerPeers_);
-          bitField0_ |= 0x00000010;
+        if (!((bitField0_ & 0x00000001) != 0)) {
+          closerPeers_ = new java.util.ArrayList<org.peergos.protocol.dht.pb.Dht.Message.Peer>(closerPeers_);
+          bitField0_ |= 0x00000001;
          }
       }
 
       private com.google.protobuf.RepeatedFieldBuilderV3<
-          Dht.Message.Peer, Dht.Message.Peer.Builder, Dht.Message.PeerOrBuilder> closerPeersBuilder_;
+          org.peergos.protocol.dht.pb.Dht.Message.Peer, org.peergos.protocol.dht.pb.Dht.Message.Peer.Builder, org.peergos.protocol.dht.pb.Dht.Message.PeerOrBuilder> closerPeersBuilder_;
 
       /**
        * <pre>
@@ -3222,9 +3462,9 @@ public final class Dht {
        * GET_VALUE, GET_PROVIDERS, FIND_NODE
        * </pre>
        *
-       * <code>repeated .org.peergos.dht.pb.Message.Peer closerPeers = 8;</code>
+       * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer closerPeers = 8;</code>
        */
-      public java.util.List<Dht.Message.Peer> getCloserPeersList() {
+      public java.util.List<org.peergos.protocol.dht.pb.Dht.Message.Peer> getCloserPeersList() {
         if (closerPeersBuilder_ == null) {
           return java.util.Collections.unmodifiableList(closerPeers_);
         } else {
@@ -3237,7 +3477,7 @@ public final class Dht {
        * GET_VALUE, GET_PROVIDERS, FIND_NODE
        * </pre>
        *
-       * <code>repeated .org.peergos.dht.pb.Message.Peer closerPeers = 8;</code>
+       * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer closerPeers = 8;</code>
        */
       public int getCloserPeersCount() {
         if (closerPeersBuilder_ == null) {
@@ -3252,9 +3492,9 @@ public final class Dht {
        * GET_VALUE, GET_PROVIDERS, FIND_NODE
        * </pre>
        *
-       * <code>repeated .org.peergos.dht.pb.Message.Peer closerPeers = 8;</code>
+       * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer closerPeers = 8;</code>
        */
-      public Dht.Message.Peer getCloserPeers(int index) {
+      public org.peergos.protocol.dht.pb.Dht.Message.Peer getCloserPeers(int index) {
         if (closerPeersBuilder_ == null) {
           return closerPeers_.get(index);
         } else {
@@ -3267,10 +3507,10 @@ public final class Dht {
        * GET_VALUE, GET_PROVIDERS, FIND_NODE
        * </pre>
        *
-       * <code>repeated .org.peergos.dht.pb.Message.Peer closerPeers = 8;</code>
+       * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer closerPeers = 8;</code>
        */
       public Builder setCloserPeers(
-          int index, Dht.Message.Peer value) {
+          int index, org.peergos.protocol.dht.pb.Dht.Message.Peer value) {
         if (closerPeersBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -3289,10 +3529,10 @@ public final class Dht {
        * GET_VALUE, GET_PROVIDERS, FIND_NODE
        * </pre>
        *
-       * <code>repeated .org.peergos.dht.pb.Message.Peer closerPeers = 8;</code>
+       * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer closerPeers = 8;</code>
        */
       public Builder setCloserPeers(
-          int index, Dht.Message.Peer.Builder builderForValue) {
+          int index, org.peergos.protocol.dht.pb.Dht.Message.Peer.Builder builderForValue) {
         if (closerPeersBuilder_ == null) {
           ensureCloserPeersIsMutable();
           closerPeers_.set(index, builderForValue.build());
@@ -3308,9 +3548,9 @@ public final class Dht {
        * GET_VALUE, GET_PROVIDERS, FIND_NODE
        * </pre>
        *
-       * <code>repeated .org.peergos.dht.pb.Message.Peer closerPeers = 8;</code>
+       * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer closerPeers = 8;</code>
        */
-      public Builder addCloserPeers(Dht.Message.Peer value) {
+      public Builder addCloserPeers(org.peergos.protocol.dht.pb.Dht.Message.Peer value) {
         if (closerPeersBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -3329,10 +3569,10 @@ public final class Dht {
        * GET_VALUE, GET_PROVIDERS, FIND_NODE
        * </pre>
        *
-       * <code>repeated .org.peergos.dht.pb.Message.Peer closerPeers = 8;</code>
+       * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer closerPeers = 8;</code>
        */
       public Builder addCloserPeers(
-          int index, Dht.Message.Peer value) {
+          int index, org.peergos.protocol.dht.pb.Dht.Message.Peer value) {
         if (closerPeersBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -3351,10 +3591,10 @@ public final class Dht {
        * GET_VALUE, GET_PROVIDERS, FIND_NODE
        * </pre>
        *
-       * <code>repeated .org.peergos.dht.pb.Message.Peer closerPeers = 8;</code>
+       * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer closerPeers = 8;</code>
        */
       public Builder addCloserPeers(
-          Dht.Message.Peer.Builder builderForValue) {
+          org.peergos.protocol.dht.pb.Dht.Message.Peer.Builder builderForValue) {
         if (closerPeersBuilder_ == null) {
           ensureCloserPeersIsMutable();
           closerPeers_.add(builderForValue.build());
@@ -3370,10 +3610,10 @@ public final class Dht {
        * GET_VALUE, GET_PROVIDERS, FIND_NODE
        * </pre>
        *
-       * <code>repeated .org.peergos.dht.pb.Message.Peer closerPeers = 8;</code>
+       * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer closerPeers = 8;</code>
        */
       public Builder addCloserPeers(
-          int index, Dht.Message.Peer.Builder builderForValue) {
+          int index, org.peergos.protocol.dht.pb.Dht.Message.Peer.Builder builderForValue) {
         if (closerPeersBuilder_ == null) {
           ensureCloserPeersIsMutable();
           closerPeers_.add(index, builderForValue.build());
@@ -3389,10 +3629,10 @@ public final class Dht {
        * GET_VALUE, GET_PROVIDERS, FIND_NODE
        * </pre>
        *
-       * <code>repeated .org.peergos.dht.pb.Message.Peer closerPeers = 8;</code>
+       * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer closerPeers = 8;</code>
        */
       public Builder addAllCloserPeers(
-          java.lang.Iterable<? extends Dht.Message.Peer> values) {
+          java.lang.Iterable<? extends org.peergos.protocol.dht.pb.Dht.Message.Peer> values) {
         if (closerPeersBuilder_ == null) {
           ensureCloserPeersIsMutable();
           com.google.protobuf.AbstractMessageLite.Builder.addAll(
@@ -3409,12 +3649,12 @@ public final class Dht {
        * GET_VALUE, GET_PROVIDERS, FIND_NODE
        * </pre>
        *
-       * <code>repeated .org.peergos.dht.pb.Message.Peer closerPeers = 8;</code>
+       * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer closerPeers = 8;</code>
        */
       public Builder clearCloserPeers() {
         if (closerPeersBuilder_ == null) {
           closerPeers_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000010);
+          bitField0_ = (bitField0_ & ~0x00000001);
           onChanged();
         } else {
           closerPeersBuilder_.clear();
@@ -3427,7 +3667,7 @@ public final class Dht {
        * GET_VALUE, GET_PROVIDERS, FIND_NODE
        * </pre>
        *
-       * <code>repeated .org.peergos.dht.pb.Message.Peer closerPeers = 8;</code>
+       * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer closerPeers = 8;</code>
        */
       public Builder removeCloserPeers(int index) {
         if (closerPeersBuilder_ == null) {
@@ -3445,9 +3685,9 @@ public final class Dht {
        * GET_VALUE, GET_PROVIDERS, FIND_NODE
        * </pre>
        *
-       * <code>repeated .org.peergos.dht.pb.Message.Peer closerPeers = 8;</code>
+       * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer closerPeers = 8;</code>
        */
-      public Dht.Message.Peer.Builder getCloserPeersBuilder(
+      public org.peergos.protocol.dht.pb.Dht.Message.Peer.Builder getCloserPeersBuilder(
           int index) {
         return getCloserPeersFieldBuilder().getBuilder(index);
       }
@@ -3457,9 +3697,9 @@ public final class Dht {
        * GET_VALUE, GET_PROVIDERS, FIND_NODE
        * </pre>
        *
-       * <code>repeated .org.peergos.dht.pb.Message.Peer closerPeers = 8;</code>
+       * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer closerPeers = 8;</code>
        */
-      public Dht.Message.PeerOrBuilder getCloserPeersOrBuilder(
+      public org.peergos.protocol.dht.pb.Dht.Message.PeerOrBuilder getCloserPeersOrBuilder(
           int index) {
         if (closerPeersBuilder_ == null) {
           return closerPeers_.get(index);  } else {
@@ -3472,9 +3712,9 @@ public final class Dht {
        * GET_VALUE, GET_PROVIDERS, FIND_NODE
        * </pre>
        *
-       * <code>repeated .org.peergos.dht.pb.Message.Peer closerPeers = 8;</code>
+       * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer closerPeers = 8;</code>
        */
-      public java.util.List<? extends Dht.Message.PeerOrBuilder>
+      public java.util.List<? extends org.peergos.protocol.dht.pb.Dht.Message.PeerOrBuilder> 
            getCloserPeersOrBuilderList() {
         if (closerPeersBuilder_ != null) {
           return closerPeersBuilder_.getMessageOrBuilderList();
@@ -3488,11 +3728,11 @@ public final class Dht {
        * GET_VALUE, GET_PROVIDERS, FIND_NODE
        * </pre>
        *
-       * <code>repeated .org.peergos.dht.pb.Message.Peer closerPeers = 8;</code>
+       * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer closerPeers = 8;</code>
        */
-      public Dht.Message.Peer.Builder addCloserPeersBuilder() {
+      public org.peergos.protocol.dht.pb.Dht.Message.Peer.Builder addCloserPeersBuilder() {
         return getCloserPeersFieldBuilder().addBuilder(
-            Dht.Message.Peer.getDefaultInstance());
+            org.peergos.protocol.dht.pb.Dht.Message.Peer.getDefaultInstance());
       }
       /**
        * <pre>
@@ -3500,12 +3740,12 @@ public final class Dht {
        * GET_VALUE, GET_PROVIDERS, FIND_NODE
        * </pre>
        *
-       * <code>repeated .org.peergos.dht.pb.Message.Peer closerPeers = 8;</code>
+       * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer closerPeers = 8;</code>
        */
-      public Dht.Message.Peer.Builder addCloserPeersBuilder(
+      public org.peergos.protocol.dht.pb.Dht.Message.Peer.Builder addCloserPeersBuilder(
           int index) {
         return getCloserPeersFieldBuilder().addBuilder(
-            index, Dht.Message.Peer.getDefaultInstance());
+            index, org.peergos.protocol.dht.pb.Dht.Message.Peer.getDefaultInstance());
       }
       /**
        * <pre>
@@ -3513,20 +3753,20 @@ public final class Dht {
        * GET_VALUE, GET_PROVIDERS, FIND_NODE
        * </pre>
        *
-       * <code>repeated .org.peergos.dht.pb.Message.Peer closerPeers = 8;</code>
+       * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer closerPeers = 8;</code>
        */
-      public java.util.List<Dht.Message.Peer.Builder>
+      public java.util.List<org.peergos.protocol.dht.pb.Dht.Message.Peer.Builder> 
            getCloserPeersBuilderList() {
         return getCloserPeersFieldBuilder().getBuilderList();
       }
       private com.google.protobuf.RepeatedFieldBuilderV3<
-          Dht.Message.Peer, Dht.Message.Peer.Builder, Dht.Message.PeerOrBuilder>
+          org.peergos.protocol.dht.pb.Dht.Message.Peer, org.peergos.protocol.dht.pb.Dht.Message.Peer.Builder, org.peergos.protocol.dht.pb.Dht.Message.PeerOrBuilder> 
           getCloserPeersFieldBuilder() {
         if (closerPeersBuilder_ == null) {
           closerPeersBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              Dht.Message.Peer, Dht.Message.Peer.Builder, Dht.Message.PeerOrBuilder>(
+              org.peergos.protocol.dht.pb.Dht.Message.Peer, org.peergos.protocol.dht.pb.Dht.Message.Peer.Builder, org.peergos.protocol.dht.pb.Dht.Message.PeerOrBuilder>(
                   closerPeers_,
-                  ((bitField0_ & 0x00000010) == 0x00000010),
+                  ((bitField0_ & 0x00000001) != 0),
                   getParentForChildren(),
                   isClean());
           closerPeers_ = null;
@@ -3534,17 +3774,17 @@ public final class Dht {
         return closerPeersBuilder_;
       }
 
-      private java.util.List<Dht.Message.Peer> providerPeers_ =
+      private java.util.List<org.peergos.protocol.dht.pb.Dht.Message.Peer> providerPeers_ =
         java.util.Collections.emptyList();
       private void ensureProviderPeersIsMutable() {
-        if (!((bitField0_ & 0x00000020) == 0x00000020)) {
-          providerPeers_ = new java.util.ArrayList<Dht.Message.Peer>(providerPeers_);
-          bitField0_ |= 0x00000020;
+        if (!((bitField0_ & 0x00000002) != 0)) {
+          providerPeers_ = new java.util.ArrayList<org.peergos.protocol.dht.pb.Dht.Message.Peer>(providerPeers_);
+          bitField0_ |= 0x00000002;
          }
       }
 
       private com.google.protobuf.RepeatedFieldBuilderV3<
-          Dht.Message.Peer, Dht.Message.Peer.Builder, Dht.Message.PeerOrBuilder> providerPeersBuilder_;
+          org.peergos.protocol.dht.pb.Dht.Message.Peer, org.peergos.protocol.dht.pb.Dht.Message.Peer.Builder, org.peergos.protocol.dht.pb.Dht.Message.PeerOrBuilder> providerPeersBuilder_;
 
       /**
        * <pre>
@@ -3552,9 +3792,9 @@ public final class Dht {
        * GET_VALUE, ADD_PROVIDER, GET_PROVIDERS
        * </pre>
        *
-       * <code>repeated .org.peergos.dht.pb.Message.Peer providerPeers = 9;</code>
+       * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer providerPeers = 9;</code>
        */
-      public java.util.List<Dht.Message.Peer> getProviderPeersList() {
+      public java.util.List<org.peergos.protocol.dht.pb.Dht.Message.Peer> getProviderPeersList() {
         if (providerPeersBuilder_ == null) {
           return java.util.Collections.unmodifiableList(providerPeers_);
         } else {
@@ -3567,7 +3807,7 @@ public final class Dht {
        * GET_VALUE, ADD_PROVIDER, GET_PROVIDERS
        * </pre>
        *
-       * <code>repeated .org.peergos.dht.pb.Message.Peer providerPeers = 9;</code>
+       * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer providerPeers = 9;</code>
        */
       public int getProviderPeersCount() {
         if (providerPeersBuilder_ == null) {
@@ -3582,9 +3822,9 @@ public final class Dht {
        * GET_VALUE, ADD_PROVIDER, GET_PROVIDERS
        * </pre>
        *
-       * <code>repeated .org.peergos.dht.pb.Message.Peer providerPeers = 9;</code>
+       * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer providerPeers = 9;</code>
        */
-      public Dht.Message.Peer getProviderPeers(int index) {
+      public org.peergos.protocol.dht.pb.Dht.Message.Peer getProviderPeers(int index) {
         if (providerPeersBuilder_ == null) {
           return providerPeers_.get(index);
         } else {
@@ -3597,10 +3837,10 @@ public final class Dht {
        * GET_VALUE, ADD_PROVIDER, GET_PROVIDERS
        * </pre>
        *
-       * <code>repeated .org.peergos.dht.pb.Message.Peer providerPeers = 9;</code>
+       * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer providerPeers = 9;</code>
        */
       public Builder setProviderPeers(
-          int index, Dht.Message.Peer value) {
+          int index, org.peergos.protocol.dht.pb.Dht.Message.Peer value) {
         if (providerPeersBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -3619,10 +3859,10 @@ public final class Dht {
        * GET_VALUE, ADD_PROVIDER, GET_PROVIDERS
        * </pre>
        *
-       * <code>repeated .org.peergos.dht.pb.Message.Peer providerPeers = 9;</code>
+       * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer providerPeers = 9;</code>
        */
       public Builder setProviderPeers(
-          int index, Dht.Message.Peer.Builder builderForValue) {
+          int index, org.peergos.protocol.dht.pb.Dht.Message.Peer.Builder builderForValue) {
         if (providerPeersBuilder_ == null) {
           ensureProviderPeersIsMutable();
           providerPeers_.set(index, builderForValue.build());
@@ -3638,9 +3878,9 @@ public final class Dht {
        * GET_VALUE, ADD_PROVIDER, GET_PROVIDERS
        * </pre>
        *
-       * <code>repeated .org.peergos.dht.pb.Message.Peer providerPeers = 9;</code>
+       * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer providerPeers = 9;</code>
        */
-      public Builder addProviderPeers(Dht.Message.Peer value) {
+      public Builder addProviderPeers(org.peergos.protocol.dht.pb.Dht.Message.Peer value) {
         if (providerPeersBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -3659,10 +3899,10 @@ public final class Dht {
        * GET_VALUE, ADD_PROVIDER, GET_PROVIDERS
        * </pre>
        *
-       * <code>repeated .org.peergos.dht.pb.Message.Peer providerPeers = 9;</code>
+       * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer providerPeers = 9;</code>
        */
       public Builder addProviderPeers(
-          int index, Dht.Message.Peer value) {
+          int index, org.peergos.protocol.dht.pb.Dht.Message.Peer value) {
         if (providerPeersBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -3681,10 +3921,10 @@ public final class Dht {
        * GET_VALUE, ADD_PROVIDER, GET_PROVIDERS
        * </pre>
        *
-       * <code>repeated .org.peergos.dht.pb.Message.Peer providerPeers = 9;</code>
+       * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer providerPeers = 9;</code>
        */
       public Builder addProviderPeers(
-          Dht.Message.Peer.Builder builderForValue) {
+          org.peergos.protocol.dht.pb.Dht.Message.Peer.Builder builderForValue) {
         if (providerPeersBuilder_ == null) {
           ensureProviderPeersIsMutable();
           providerPeers_.add(builderForValue.build());
@@ -3700,10 +3940,10 @@ public final class Dht {
        * GET_VALUE, ADD_PROVIDER, GET_PROVIDERS
        * </pre>
        *
-       * <code>repeated .org.peergos.dht.pb.Message.Peer providerPeers = 9;</code>
+       * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer providerPeers = 9;</code>
        */
       public Builder addProviderPeers(
-          int index, Dht.Message.Peer.Builder builderForValue) {
+          int index, org.peergos.protocol.dht.pb.Dht.Message.Peer.Builder builderForValue) {
         if (providerPeersBuilder_ == null) {
           ensureProviderPeersIsMutable();
           providerPeers_.add(index, builderForValue.build());
@@ -3719,10 +3959,10 @@ public final class Dht {
        * GET_VALUE, ADD_PROVIDER, GET_PROVIDERS
        * </pre>
        *
-       * <code>repeated .org.peergos.dht.pb.Message.Peer providerPeers = 9;</code>
+       * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer providerPeers = 9;</code>
        */
       public Builder addAllProviderPeers(
-          java.lang.Iterable<? extends Dht.Message.Peer> values) {
+          java.lang.Iterable<? extends org.peergos.protocol.dht.pb.Dht.Message.Peer> values) {
         if (providerPeersBuilder_ == null) {
           ensureProviderPeersIsMutable();
           com.google.protobuf.AbstractMessageLite.Builder.addAll(
@@ -3739,12 +3979,12 @@ public final class Dht {
        * GET_VALUE, ADD_PROVIDER, GET_PROVIDERS
        * </pre>
        *
-       * <code>repeated .org.peergos.dht.pb.Message.Peer providerPeers = 9;</code>
+       * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer providerPeers = 9;</code>
        */
       public Builder clearProviderPeers() {
         if (providerPeersBuilder_ == null) {
           providerPeers_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000020);
+          bitField0_ = (bitField0_ & ~0x00000002);
           onChanged();
         } else {
           providerPeersBuilder_.clear();
@@ -3757,7 +3997,7 @@ public final class Dht {
        * GET_VALUE, ADD_PROVIDER, GET_PROVIDERS
        * </pre>
        *
-       * <code>repeated .org.peergos.dht.pb.Message.Peer providerPeers = 9;</code>
+       * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer providerPeers = 9;</code>
        */
       public Builder removeProviderPeers(int index) {
         if (providerPeersBuilder_ == null) {
@@ -3775,9 +4015,9 @@ public final class Dht {
        * GET_VALUE, ADD_PROVIDER, GET_PROVIDERS
        * </pre>
        *
-       * <code>repeated .org.peergos.dht.pb.Message.Peer providerPeers = 9;</code>
+       * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer providerPeers = 9;</code>
        */
-      public Dht.Message.Peer.Builder getProviderPeersBuilder(
+      public org.peergos.protocol.dht.pb.Dht.Message.Peer.Builder getProviderPeersBuilder(
           int index) {
         return getProviderPeersFieldBuilder().getBuilder(index);
       }
@@ -3787,9 +4027,9 @@ public final class Dht {
        * GET_VALUE, ADD_PROVIDER, GET_PROVIDERS
        * </pre>
        *
-       * <code>repeated .org.peergos.dht.pb.Message.Peer providerPeers = 9;</code>
+       * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer providerPeers = 9;</code>
        */
-      public Dht.Message.PeerOrBuilder getProviderPeersOrBuilder(
+      public org.peergos.protocol.dht.pb.Dht.Message.PeerOrBuilder getProviderPeersOrBuilder(
           int index) {
         if (providerPeersBuilder_ == null) {
           return providerPeers_.get(index);  } else {
@@ -3802,9 +4042,9 @@ public final class Dht {
        * GET_VALUE, ADD_PROVIDER, GET_PROVIDERS
        * </pre>
        *
-       * <code>repeated .org.peergos.dht.pb.Message.Peer providerPeers = 9;</code>
+       * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer providerPeers = 9;</code>
        */
-      public java.util.List<? extends Dht.Message.PeerOrBuilder>
+      public java.util.List<? extends org.peergos.protocol.dht.pb.Dht.Message.PeerOrBuilder> 
            getProviderPeersOrBuilderList() {
         if (providerPeersBuilder_ != null) {
           return providerPeersBuilder_.getMessageOrBuilderList();
@@ -3818,11 +4058,11 @@ public final class Dht {
        * GET_VALUE, ADD_PROVIDER, GET_PROVIDERS
        * </pre>
        *
-       * <code>repeated .org.peergos.dht.pb.Message.Peer providerPeers = 9;</code>
+       * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer providerPeers = 9;</code>
        */
-      public Dht.Message.Peer.Builder addProviderPeersBuilder() {
+      public org.peergos.protocol.dht.pb.Dht.Message.Peer.Builder addProviderPeersBuilder() {
         return getProviderPeersFieldBuilder().addBuilder(
-            Dht.Message.Peer.getDefaultInstance());
+            org.peergos.protocol.dht.pb.Dht.Message.Peer.getDefaultInstance());
       }
       /**
        * <pre>
@@ -3830,12 +4070,12 @@ public final class Dht {
        * GET_VALUE, ADD_PROVIDER, GET_PROVIDERS
        * </pre>
        *
-       * <code>repeated .org.peergos.dht.pb.Message.Peer providerPeers = 9;</code>
+       * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer providerPeers = 9;</code>
        */
-      public Dht.Message.Peer.Builder addProviderPeersBuilder(
+      public org.peergos.protocol.dht.pb.Dht.Message.Peer.Builder addProviderPeersBuilder(
           int index) {
         return getProviderPeersFieldBuilder().addBuilder(
-            index, Dht.Message.Peer.getDefaultInstance());
+            index, org.peergos.protocol.dht.pb.Dht.Message.Peer.getDefaultInstance());
       }
       /**
        * <pre>
@@ -3843,30 +4083,126 @@ public final class Dht {
        * GET_VALUE, ADD_PROVIDER, GET_PROVIDERS
        * </pre>
        *
-       * <code>repeated .org.peergos.dht.pb.Message.Peer providerPeers = 9;</code>
+       * <code>repeated .org.peergos.protocol.dht.pb.Message.Peer providerPeers = 9;</code>
        */
-      public java.util.List<Dht.Message.Peer.Builder>
+      public java.util.List<org.peergos.protocol.dht.pb.Dht.Message.Peer.Builder> 
            getProviderPeersBuilderList() {
         return getProviderPeersFieldBuilder().getBuilderList();
       }
       private com.google.protobuf.RepeatedFieldBuilderV3<
-          Dht.Message.Peer, Dht.Message.Peer.Builder, Dht.Message.PeerOrBuilder>
+          org.peergos.protocol.dht.pb.Dht.Message.Peer, org.peergos.protocol.dht.pb.Dht.Message.Peer.Builder, org.peergos.protocol.dht.pb.Dht.Message.PeerOrBuilder> 
           getProviderPeersFieldBuilder() {
         if (providerPeersBuilder_ == null) {
           providerPeersBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              Dht.Message.Peer, Dht.Message.Peer.Builder, Dht.Message.PeerOrBuilder>(
+              org.peergos.protocol.dht.pb.Dht.Message.Peer, org.peergos.protocol.dht.pb.Dht.Message.Peer.Builder, org.peergos.protocol.dht.pb.Dht.Message.PeerOrBuilder>(
                   providerPeers_,
-                  ((bitField0_ & 0x00000020) == 0x00000020),
+                  ((bitField0_ & 0x00000002) != 0),
                   getParentForChildren(),
                   isClean());
           providerPeers_ = null;
         }
         return providerPeersBuilder_;
       }
+
+      private java.lang.Object traceId_ = "";
+      /**
+       * <pre>
+       * Trace Id.
+       * </pre>
+       *
+       * <code>string traceId = 11;</code>
+       * @return The traceId.
+       */
+      public java.lang.String getTraceId() {
+        java.lang.Object ref = traceId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          traceId_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Trace Id.
+       * </pre>
+       *
+       * <code>string traceId = 11;</code>
+       * @return The bytes for traceId.
+       */
+      public com.google.protobuf.ByteString
+          getTraceIdBytes() {
+        java.lang.Object ref = traceId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          traceId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Trace Id.
+       * </pre>
+       *
+       * <code>string traceId = 11;</code>
+       * @param value The traceId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setTraceId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        traceId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Trace Id.
+       * </pre>
+       *
+       * <code>string traceId = 11;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearTraceId() {
+        
+        traceId_ = getDefaultInstance().getTraceId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Trace Id.
+       * </pre>
+       *
+       * <code>string traceId = 11;</code>
+       * @param value The bytes for traceId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setTraceIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        traceId_ = value;
+        onChanged();
+        return this;
+      }
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
-        return super.setUnknownFieldsProto3(unknownFields);
+        return super.setUnknownFields(unknownFields);
       }
 
       @java.lang.Override
@@ -3876,16 +4212,16 @@ public final class Dht {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:org.peergos.dht.pb.Message)
+      // @@protoc_insertion_point(builder_scope:org.peergos.protocol.dht.pb.Message)
     }
 
-    // @@protoc_insertion_point(class_scope:org.peergos.dht.pb.Message)
-    private static final Dht.Message DEFAULT_INSTANCE;
+    // @@protoc_insertion_point(class_scope:org.peergos.protocol.dht.pb.Message)
+    private static final org.peergos.protocol.dht.pb.Dht.Message DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE = new Dht.Message();
+      DEFAULT_INSTANCE = new org.peergos.protocol.dht.pb.Dht.Message();
     }
 
-    public static Dht.Message getDefaultInstance() {
+    public static org.peergos.protocol.dht.pb.Dht.Message getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
@@ -3910,27 +4246,27 @@ public final class Dht {
     }
 
     @java.lang.Override
-    public Dht.Message getDefaultInstanceForType() {
+    public org.peergos.protocol.dht.pb.Dht.Message getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
   }
 
   private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_org_peergos_dht_pb_Record_descriptor;
+    internal_static_org_peergos_protocol_dht_pb_Record_descriptor;
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_org_peergos_dht_pb_Record_fieldAccessorTable;
+      internal_static_org_peergos_protocol_dht_pb_Record_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_org_peergos_dht_pb_Message_descriptor;
+    internal_static_org_peergos_protocol_dht_pb_Message_descriptor;
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_org_peergos_dht_pb_Message_fieldAccessorTable;
+      internal_static_org_peergos_protocol_dht_pb_Message_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_org_peergos_dht_pb_Message_Peer_descriptor;
+    internal_static_org_peergos_protocol_dht_pb_Message_Peer_descriptor;
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_org_peergos_dht_pb_Message_Peer_fieldAccessorTable;
+      internal_static_org_peergos_protocol_dht_pb_Message_Peer_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
@@ -3940,53 +4276,47 @@ public final class Dht {
       descriptor;
   static {
     java.lang.String[] descriptorData = {
-      "\n\tdht.proto\022\022org.peergos.dht.pb\":\n\006Recor" +
-      "d\022\013\n\003key\030\001 \001(\014\022\r\n\005value\030\002 \001(\014\022\024\n\014timeRec" +
-      "eived\030\005 \001(\t\"\251\004\n\007Message\0225\n\004type\030\001 \001(\0162\'." +
-      "org.peergos.dht.pb.Message.MessageType\022\027" +
-      "\n\017clusterLevelRaw\030\n \001(\005\022\013\n\003key\030\002 \001(\014\022*\n\006" +
-      "record\030\003 \001(\0132\032.org.peergos.dht.pb.Record" +
-      "\0225\n\013closerPeers\030\010 \003(\0132 .org.peergos.dht." +
-      "pb.Message.Peer\0227\n\rproviderPeers\030\t \003(\0132 " +
-      ".org.peergos.dht.pb.Message.Peer\032a\n\004Peer" +
-      "\022\n\n\002id\030\001 \001(\014\022\r\n\005addrs\030\002 \003(\014\022>\n\nconnectio" +
-      "n\030\003 \001(\0162*.org.peergos.dht.pb.Message.Con" +
-      "nectionType\"i\n\013MessageType\022\r\n\tPUT_VALUE\020" +
-      "\000\022\r\n\tGET_VALUE\020\001\022\020\n\014ADD_PROVIDER\020\002\022\021\n\rGE" +
-      "T_PROVIDERS\020\003\022\r\n\tFIND_NODE\020\004\022\010\n\004PING\020\005\"W" +
-      "\n\016ConnectionType\022\021\n\rNOT_CONNECTED\020\000\022\r\n\tC" +
-      "ONNECTED\020\001\022\017\n\013CAN_CONNECT\020\002\022\022\n\016CANNOT_CO" +
-      "NNECT\020\003b\006proto3"
+      "\n\tdht.proto\022\033org.peergos.protocol.dht.pb" +
+      "\":\n\006Record\022\013\n\003key\030\001 \001(\014\022\r\n\005value\030\002 \001(\014\022\024" +
+      "\n\014timeReceived\030\005 \001(\t\"\347\004\n\007Message\022>\n\004type" +
+      "\030\001 \001(\01620.org.peergos.protocol.dht.pb.Mes" +
+      "sage.MessageType\022\027\n\017clusterLevelRaw\030\n \001(" +
+      "\005\022\013\n\003key\030\002 \001(\014\0223\n\006record\030\003 \001(\0132#.org.pee" +
+      "rgos.protocol.dht.pb.Record\022>\n\013closerPee" +
+      "rs\030\010 \003(\0132).org.peergos.protocol.dht.pb.M" +
+      "essage.Peer\022@\n\rproviderPeers\030\t \003(\0132).org" +
+      ".peergos.protocol.dht.pb.Message.Peer\022\017\n" +
+      "\007traceId\030\013 \001(\t\032j\n\004Peer\022\n\n\002id\030\001 \001(\014\022\r\n\005ad" +
+      "drs\030\002 \003(\014\022G\n\nconnection\030\003 \001(\01623.org.peer" +
+      "gos.protocol.dht.pb.Message.ConnectionTy" +
+      "pe\"i\n\013MessageType\022\r\n\tPUT_VALUE\020\000\022\r\n\tGET_" +
+      "VALUE\020\001\022\020\n\014ADD_PROVIDER\020\002\022\021\n\rGET_PROVIDE" +
+      "RS\020\003\022\r\n\tFIND_NODE\020\004\022\010\n\004PING\020\005\"W\n\016Connect" +
+      "ionType\022\021\n\rNOT_CONNECTED\020\000\022\r\n\tCONNECTED\020" +
+      "\001\022\017\n\013CAN_CONNECT\020\002\022\022\n\016CANNOT_CONNECT\020\003b\006" +
+      "proto3"
     };
-    com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
-        new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
-          public com.google.protobuf.ExtensionRegistry assignDescriptors(
-              com.google.protobuf.Descriptors.FileDescriptor root) {
-            descriptor = root;
-            return null;
-          }
-        };
-    com.google.protobuf.Descriptors.FileDescriptor
+    descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
         new com.google.protobuf.Descriptors.FileDescriptor[] {
-        }, assigner);
-    internal_static_org_peergos_dht_pb_Record_descriptor =
+        });
+    internal_static_org_peergos_protocol_dht_pb_Record_descriptor =
       getDescriptor().getMessageTypes().get(0);
-    internal_static_org_peergos_dht_pb_Record_fieldAccessorTable = new
+    internal_static_org_peergos_protocol_dht_pb_Record_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_org_peergos_dht_pb_Record_descriptor,
+        internal_static_org_peergos_protocol_dht_pb_Record_descriptor,
         new java.lang.String[] { "Key", "Value", "TimeReceived", });
-    internal_static_org_peergos_dht_pb_Message_descriptor =
+    internal_static_org_peergos_protocol_dht_pb_Message_descriptor =
       getDescriptor().getMessageTypes().get(1);
-    internal_static_org_peergos_dht_pb_Message_fieldAccessorTable = new
+    internal_static_org_peergos_protocol_dht_pb_Message_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_org_peergos_dht_pb_Message_descriptor,
-        new java.lang.String[] { "Type", "ClusterLevelRaw", "Key", "Record", "CloserPeers", "ProviderPeers", });
-    internal_static_org_peergos_dht_pb_Message_Peer_descriptor =
-      internal_static_org_peergos_dht_pb_Message_descriptor.getNestedTypes().get(0);
-    internal_static_org_peergos_dht_pb_Message_Peer_fieldAccessorTable = new
+        internal_static_org_peergos_protocol_dht_pb_Message_descriptor,
+        new java.lang.String[] { "Type", "ClusterLevelRaw", "Key", "Record", "CloserPeers", "ProviderPeers", "TraceId", });
+    internal_static_org_peergos_protocol_dht_pb_Message_Peer_descriptor =
+      internal_static_org_peergos_protocol_dht_pb_Message_descriptor.getNestedTypes().get(0);
+    internal_static_org_peergos_protocol_dht_pb_Message_Peer_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_org_peergos_dht_pb_Message_Peer_descriptor,
+        internal_static_org_peergos_protocol_dht_pb_Message_Peer_descriptor,
         new java.lang.String[] { "Id", "Addrs", "Connection", });
   }
 

--- a/src/main/java/org/peergos/util/TraceLogger.java
+++ b/src/main/java/org/peergos/util/TraceLogger.java
@@ -1,0 +1,252 @@
+package org.peergos.util;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.UUID;
+
+import org.peergos.protocol.bitswap.pb.MessageOuterClass;
+import org.peergos.protocol.dht.pb.Dht;
+
+import io.ipfs.cid.Cid;
+import io.libp2p.core.PeerId;
+
+/**
+ * Logs thread traces to the trace file. This is a singleton class.
+ */
+public class TraceLogger {
+    /**
+     * Returns the singleton instance of the TraceLogger.
+     */
+    public static TraceLogger getInstance() {
+        if (traceLogger == null) {
+            traceLogger = new TraceLogger();
+        }
+        return traceLogger;
+    }
+
+    /**
+     * Sets the identity of the current node.
+     * 
+     * @param peerId Identity of the current node.
+     */
+    public void setIdentity(PeerId peerId) {
+        currentNodeId = nodeIdMap.get(peerId.toString());
+    }
+
+    /**
+     * Starts recording the traces for all subsequent trace points on the current
+     * thread and child threads.
+     * Also propagates the trace context to servers.
+     */
+    public void startTrace() {
+        TraceContext.setTraceId(UUID.randomUUID().toString());
+    }
+
+    /**
+     * Ends recording the traces for the current thread.
+     */
+    public void endTrace() {
+        TraceContext.clearTraceId();
+    }
+
+    /**
+     * Logs (if trace context is available) the client start of a kademlia lookup.
+     */
+    public Dht.Message HandleKademliaClientStart(Dht.Message msg, PeerId remotePeerId) {
+        if (msg.getType() != Dht.Message.MessageType.GET_PROVIDERS || !TraceContext.isSet()) {
+            return msg;
+        }
+        writeLog(TraceType.GET_PROVIDERS_CLIENT_START, "Peer nodeId: " + nodeIdMap.get(remotePeerId.toString()));
+        return msg.toBuilder().setTraceId(TraceContext.getTraceId()).build();
+    }
+
+    /**
+     * Logs (if trace context is available) the server start of a kademlia lookup.
+     */
+    public void HandleKademliaServerStart(Dht.Message msg, PeerId remotePeerId) {
+        if (msg.getType() != Dht.Message.MessageType.GET_PROVIDERS || msg.getTraceId().isEmpty()) {
+            return;
+        }
+        TraceContext.setTraceId(msg.getTraceId());
+        writeLog(TraceType.GET_PROVIDERS_SERVER_START, "Peer nodeId: " + nodeIdMap.get(remotePeerId.toString()));
+    }
+
+    /**
+     * Logs (if trace context is available) the server end of a kademlia lookup.
+     */
+    public void HandleKademliaServerEnd(Dht.Message msg, PeerId remotePeerId) {
+        if (msg.getType() != Dht.Message.MessageType.GET_PROVIDERS || !TraceContext.isSet()) {
+            return;
+        }
+        writeLog(TraceType.GET_PROVIDERS_SERVER_END, "Peer nodeId: " + nodeIdMap.get(remotePeerId.toString()));
+        TraceContext.clearTraceId();
+    }
+
+    /**
+     * Logs (if trace context is available) the client end of a kademlia lookup.
+     */
+    public void HandleKademliaClientEnd(Dht.Message msg, PeerId remotePeerId) {
+        if (msg.getType() != Dht.Message.MessageType.GET_PROVIDERS || !TraceContext.isSet()) {
+            return;
+        }
+        writeLog(TraceType.GET_PROVIDERS_CLIENT_END, "Peer nodeId: " + nodeIdMap.get(remotePeerId.toString()));
+    }
+
+    /**
+     * Logs (if trace context is available) the client start of a bitswap protocol.
+     */
+    public MessageOuterClass.Message HandleBitswapClientStart(MessageOuterClass.Message msg, PeerId remotePeerId) {
+        if (!TraceContext.isSet()) {
+            return msg;
+        }
+        writeLog(TraceType.BITSWAP_CLIENT_START,
+                "Want " + msg.getWantlist().getEntriesCount() + " hashes. Peer nodeId: "
+                        + nodeIdMap.get(remotePeerId.toString()));
+        return msg.toBuilder().setTraceId(TraceContext.getTraceId()).build();
+    }
+
+    /**
+     * Logs (if trace context is available) the server start or client end of a
+     * bitswap protocol.
+     */
+    public void HandleBitswapReceive(MessageOuterClass.Message msg, PeerId remotePeerId) {
+        if (msg.getTraceId().isEmpty()) {
+            return;
+        }
+        TraceContext.setTraceId(msg.getTraceId());
+        boolean isServer = msg.hasWantlist();
+        writeLog(isServer ? TraceType.BITSWAP_SERVER_START : TraceType.BITSWAP_CLIENT_END,
+                isServer ? "Want " + msg.getWantlist().getEntriesCount() + " hashes. Peer nodeId: "
+                        + nodeIdMap.get(remotePeerId.toString())
+                        : msg.getPayloadCount() + " blocks. Peer nodeId: " + nodeIdMap.get(remotePeerId.toString()));
+        if (!isServer) {
+            TraceContext.clearTraceId();
+        }
+    }
+
+    /**
+     * Logs (if trace context is available) the server end of a bitswap protocol.
+     */
+    public void HandleBitswapServerEnd(MessageOuterClass.Message msg, PeerId remotePeerId) {
+        if (!TraceContext.isSet()) {
+            return;
+        }
+        writeLog(TraceType.BITSWAP_SERVER_END,
+                msg.getPayloadCount() + " blocks. Peer nodeId: " + nodeIdMap.get(remotePeerId.toString()));
+        TraceContext.clearTraceId();
+    }
+
+    /**
+     * Logs (if trace context is available) the start of a file read.
+     * 
+     * @param cid Content id of the file.
+     */
+    public void HandleFileReadStart(Cid cid) {
+        if (TraceContext.isSet()) {
+            writeLog(TraceType.READ_FROM_FILE_STORE_START, "Cid: " + cid.toString());
+        }
+    }
+
+    /**
+     * Logs (if trace context is available) the end of a file read.
+     * 
+     * @param cid Content id of the file.
+     */
+    public void HandleFileReadEnd(Cid cid) {
+        if (TraceContext.isSet()) {
+            writeLog(TraceType.READ_FROM_FILE_STORE_END, "Cid: " + cid.toString());
+        }
+    }
+
+    // -------------- PRIVATE MEMBERS -------------
+
+    /**
+     * Holds the context for the current thread trace. The context contains the
+     * trace Id.
+     */
+    private static class TraceContext {
+        private static final ThreadLocal<String> traceId = new InheritableThreadLocal<String>() {
+            @Override
+            protected String initialValue() {
+                return "";
+            }
+        };
+
+        public static boolean isSet() {
+            return !traceId.get().isEmpty();
+        }
+
+        public static String getTraceId() {
+            return traceId.get();
+        }
+
+        public static void setTraceId(String newTraceId) {
+            traceId.set(newTraceId);
+        }
+
+        public static void clearTraceId() {
+            traceId.set("");
+        }
+    }
+
+    /**
+     * Represents different types of log points that are captured by the trace
+     * logger.
+     */
+    private enum TraceType {
+        // Catch all.
+        UNKNOWN,
+
+        // Kademlia lookup.
+        GET_PROVIDERS_CLIENT_START,
+        GET_PROVIDERS_SERVER_START,
+        GET_PROVIDERS_SERVER_END,
+        GET_PROVIDERS_CLIENT_END,
+
+        // Bitswap.
+        BITSWAP_CLIENT_START,
+        BITSWAP_SERVER_START,
+        BITSWAP_SERVER_END,
+        BITSWAP_CLIENT_END,
+
+        // File read.
+        READ_FROM_FILE_STORE_START,
+        READ_FROM_FILE_STORE_END,
+    };
+
+    // Maps peer Id (as string) to node Id.
+    private HashMap<String, Integer> nodeIdMap;
+    private int currentNodeId;
+
+    private static TraceLogger traceLogger = null;
+
+    private TraceLogger() {
+        // TODO(sonudoo): Remove a hardcoded mapping of peer Id to node Id.
+        nodeIdMap = new HashMap<>();
+        nodeIdMap.put("12D3KooWMDHFtZjTZ6Hdi5WEQPBxJp7gT4yqtQkne6DCqiQCBP73", 0);
+        nodeIdMap.put("12D3KooWNdeb2dTYZ9X4T1PREUoFgR8f3yrGbMjMsd8PSZgcBZ3s", 1);
+        nodeIdMap.put("12D3KooWNvMgnv9iHJDcEKRriGc7zT5NcTwffaKE1XgZRUZ1BDPe", 2);
+        nodeIdMap.put("12D3KooWHA6vxTu6F2grKnErGsZMMJiBXVJvAoCQzhKM5KcFgrDR", 3);
+        nodeIdMap.put("12D3KooWDbhwoVhREeDsZ8HHj6LfsykRJnG7TA8wEfXGQfnhiSBf", 4);
+        nodeIdMap.put("12D3KooWT1gBjWRTJuyqGa4dRuHyexGUBAR2Psoh6hqqAGej6Bc5", 5);
+        nodeIdMap.put("12D3KooWH8vCRRoH73tV7KaXf6o1dzJms7FxH7hd3M3eYSjF9zC7", 6);
+        nodeIdMap.put("12D3KooWHyor6CQ21vMhtSJ2qb1YEBfv9vgpe1VgA5iMYT4DTd9T", 7);
+        nodeIdMap.put("12D3KooWJWcBwDHBo7ecoBCsT8FJWvQax4Wmn2iKTCvG6uhLKZN6", 8);
+        nodeIdMap.put("12D3KooWCfWmdJYdAUwm1pTxFKsRDRzGmsbeUMpriNNocMDVMmum", 9);
+        currentNodeId = -1;
+    }
+
+    private void writeLog(TraceType type, String debugDetails) {
+        StringBuilder builder = new StringBuilder();
+        builder.append(TraceContext.getTraceId() + "\t");
+        builder.append(currentNodeId + "\t");
+        builder.append(Thread.currentThread().getId() + "\t");
+        long currentTimeMillis = System.currentTimeMillis();
+        builder.append(currentTimeMillis + "\t");
+        builder.append(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS").format(new Date(currentTimeMillis)) + "\t");
+        builder.append(type.name() + "\t");
+        builder.append(debugDetails);
+        System.out.println(builder.toString());
+    }
+}

--- a/src/main/protobuf/dht.proto
+++ b/src/main/protobuf/dht.proto
@@ -78,4 +78,8 @@ message Message {
 	// Used to return Providers
 	// GET_VALUE, ADD_PROVIDER, GET_PROVIDERS
 	repeated Peer providerPeers = 9;// [(gogoproto.nullable) = false];
+
+  	// TODO(sonudoo): Traces must be propagated at internal protobuf level.
+	// Trace Id.
+	string traceId = 11;
 }

--- a/src/main/protobuf/message.proto
+++ b/src/main/protobuf/message.proto
@@ -44,4 +44,6 @@ message Message {
   repeated Block payload = 3; //[(gogoproto.nullable) = false];		// used to send Blocks in bitswap 1.1.0
   repeated BlockPresence blockPresences = 4; //[(gogoproto.nullable) = false];
   int32 pendingBytes = 5;
+  // TODO(sonudoo): Traces must be propagated at internal protobuf level.
+  string traceId = 6;
 }


### PR DESCRIPTION
The log format is:

`<trace-id> <node-id> <thread-id> <timestamp> <human-readable-time> <event-type> <details>
`

All retrieval requests will be traced.

Pending TODOs:

- There is a bug which accidently propagaes an old trace Id for new requests. Needs some deeper investigation.
- Currently, time is being fetched from local machine. Need to switch over to NTP.
- Expose an HTTP handler to issue retrieval requests.