### PR TITLE
Multiple changes

### DIFF
--- a/install-run-ipfs.sh
+++ b/install-run-ipfs.sh
@@ -1,7 +1,0 @@
-#! /bin/sh
-wget https://dist.ipfs.io/kubo/v0.20.0/kubo_v0.20.0_linux-amd64.tar.gz -O /tmp/kubo_linux-amd64.tar.gz
-tar -xvf /tmp/kubo_linux-amd64.tar.gz
-export PATH=$PATH:$PWD/kubo/
-ipfs init
-ipfs daemon --routing=dhtserver &
-sleep 10s

--- a/run-local.sh
+++ b/run-local.sh
@@ -1,3 +1,3 @@
 # Usage: ./run-local.sh <node-id>
 
-java -cp target/nabu-v0.7.7-jar-with-dependencies.jar org.peergos.Client -id $1 -local
+java -Xms1g -Xmx1g -cp target/nabu-v0.7.7-jar-with-dependencies.jar org.peergos.Client -id $1 -local

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,3 @@
 # Usage: ./run.sh <node-id>
 
-java -cp target/nabu-v0.7.7-jar-with-dependencies.jar org.peergos.Client -id $1
+java -Xms1g -Xmx1g -cp target/nabu-v0.7.7-jar-with-dependencies.jar org.peergos.Client -id $1

--- a/src/main/java/org/peergos/Client.java
+++ b/src/main/java/org/peergos/Client.java
@@ -79,7 +79,7 @@ public class Client {
         InetSocketAddress localAPIAddress = new InetSocketAddress(apiAddress.getHost(), apiAddress.getPort());
 
         int maxConnectionQueue = 500;
-        int handlerThreads = 50;
+        int handlerThreads = 5;
         LOG.info("Starting HTTP API server at " + apiAddress.getHost() + ":" + localAPIAddress.getPort());
         HttpServer httpServer = HttpServer.create(localAPIAddress, maxConnectionQueue);
 

--- a/src/main/java/org/peergos/net/APIHandler.java
+++ b/src/main/java/org/peergos/net/APIHandler.java
@@ -16,7 +16,7 @@ public class APIHandler extends Handler {
     public static final Version CURRENT_VERSION = Version.parse("0.7.7");
     public static final String GET = "block/get";
     public static final String PUT = "block/put";
-    public static final String HEALTH = "health";
+    public static final String HEALTHZ = "healthz";
 
     private final EmbeddedIpfs ipfs;
     private final int maxBlockSize;
@@ -74,7 +74,7 @@ public class APIHandler extends Handler {
                     replyJson(httpExchange, JSONParser.toString(res));
                     break;
                 }
-                case HEALTH: {
+                case HEALTHZ: {
                     try {
                         httpExchange.sendResponseHeaders(200, 0);
                     } catch (IOException ioe) {

--- a/src/main/java/org/peergos/net/APIHandler.java
+++ b/src/main/java/org/peergos/net/APIHandler.java
@@ -16,6 +16,7 @@ public class APIHandler extends Handler {
     public static final Version CURRENT_VERSION = Version.parse("0.7.7");
     public static final String GET = "block/get";
     public static final String PUT = "block/put";
+    public static final String HEALTH = "health";
 
     private final EmbeddedIpfs ipfs;
     private final int maxBlockSize;
@@ -71,6 +72,14 @@ public class APIHandler extends Handler {
                     Map res = new HashMap<>();
                     res.put("cid", cid.toString());
                     replyJson(httpExchange, JSONParser.toString(res));
+                    break;
+                }
+                case HEALTH: {
+                    try {
+                        httpExchange.sendResponseHeaders(200, 0);
+                    } catch (IOException ioe) {
+                        HttpUtil.replyError(httpExchange, ioe);
+                    }
                     break;
                 }
                 default: {


### PR DESCRIPTION
- Reduce the number of threads for API server. This will lead to contention and help us generate good delay traces.
- Add an API to run health check on the Nabu backend. This will be used to find healthy backends.