### PR TITLE
Change traceId size

### DIFF
--- a/src/main/java/org/peergos/util/TraceLogger.java
+++ b/src/main/java/org/peergos/util/TraceLogger.java
@@ -22,9 +22,9 @@ import io.libp2p.core.PeerId;
  */
 public class TraceLogger {
     /**
-     * Character length of a traceId.
+     * Size of a traceId.
      */
-    private static final int TRACE_ID_LENGTH = 16;
+    private static final int TRACE_ID_SIZE_IN_BYTES = 16;
 
     /**
      * Returns the singleton instance of the TraceLogger.
@@ -50,7 +50,7 @@ public class TraceLogger {
      * 
      * @return traceId The randomly generated traceId.
      */
-    public String generateTraceId(int traceIdLength) {
+    public String generateTraceId(int traceIdSize) {
         Random random = new Random();
         byte[] bytes = new byte[8]; // 8 bytes * 2 hex characters per byte = 16 hex characters
         random.nextBytes(bytes);
@@ -69,7 +69,7 @@ public class TraceLogger {
      * Also propagates the trace context to servers.
      */
     public void startTrace() {
-        TraceContext.setTraceId(generateTraceId(TRACE_ID_LENGTH));
+        TraceContext.setTraceId(generateTraceId(TRACE_ID_SIZE_IN_BYTES));
     }
 
     /**

--- a/src/main/java/org/peergos/util/TraceLogger.java
+++ b/src/main/java/org/peergos/util/TraceLogger.java
@@ -46,13 +46,13 @@ public class TraceLogger {
     }
 
     /**
-     * Generates a random Hex string of length traceIdSize * 2
+     * Generates a random Hex string of length traceIdSizeInBytes * 2
      * 
      * @return traceId The randomly generated traceId.
      */
-    public String generateTraceId(int traceIdSize) {
+    public String generateTraceId(int traceIdSizeInBytes) {
         Random random = new Random();
-        byte[] bytes = new byte[traceIdSize]; // length will be traceIdSize * 2 hex chars
+        byte[] bytes = new byte[traceIdSizeInBytes]; // length will be length traceIdSizeInBytes * 2 hex chars
         random.nextBytes(bytes);
 
         StringBuilder builder = new StringBuilder();

--- a/src/main/java/org/peergos/util/TraceLogger.java
+++ b/src/main/java/org/peergos/util/TraceLogger.java
@@ -24,7 +24,7 @@ public class TraceLogger {
     /**
      * Size of a traceId.
      */
-    private static final int TRACE_ID_SIZE_IN_BYTES = 8;
+    private static final int TRACE_ID_SIZE_IN_BYTES = 16;
 
     /**
      * Returns the singleton instance of the TraceLogger.

--- a/src/main/java/org/peergos/util/TraceLogger.java
+++ b/src/main/java/org/peergos/util/TraceLogger.java
@@ -41,25 +41,6 @@ public class TraceLogger {
     }
 
     /**
-     * Generates a random 32 character hex string.
-     * 
-     * @return traceId The randomly generated traceId.
-     */
-    private String generateTraceId() {
-        Random random = new Random();
-        StringBuilder builder = new StringBuilder();
-
-        byte[] bytes = new byte[16]; // length will be length 32 hex chars
-        random.nextBytes(bytes);
-
-        for (byte b : bytes) {
-            builder.append(String.format("%02x", b));
-        }
-
-        return builder.toString();
-    }
-
-    /**
      * Starts recording the traces for all subsequent trace points on the current
      * thread and child threads.
      * Also propagates the trace context to servers.
@@ -198,6 +179,25 @@ public class TraceLogger {
     }
 
     // -------------- PRIVATE MEMBERS -------------
+
+    /**
+     * Generates a random 32 character hex string.
+     * 
+     * @return traceId The randomly generated traceId.
+     */
+    private String generateTraceId() {
+        Random random = new Random();
+        StringBuilder builder = new StringBuilder();
+
+        byte[] bytes = new byte[16]; // length will be length 32 hex chars
+        random.nextBytes(bytes);
+
+        for (byte b : bytes) {
+            builder.append(String.format("%02x", b));
+        }
+
+        return builder.toString();
+    }
 
     /**
      * Holds the context for the current thread trace. The context contains the

--- a/src/main/java/org/peergos/util/TraceLogger.java
+++ b/src/main/java/org/peergos/util/TraceLogger.java
@@ -22,11 +22,6 @@ import io.libp2p.core.PeerId;
  */
 public class TraceLogger {
     /**
-     * Size of a traceId.
-     */
-    private static final int TRACE_ID_SIZE_IN_BYTES = 16;
-
-    /**
      * Returns the singleton instance of the TraceLogger.
      */
     public static TraceLogger getInstance() {
@@ -46,16 +41,17 @@ public class TraceLogger {
     }
 
     /**
-     * Generates a random Hex string of length traceIdSizeInBytes * 2
+     * Generates a random 32 character hex string.
      * 
      * @return traceId The randomly generated traceId.
      */
-    public String generateTraceId(int traceIdSizeInBytes) {
+    private String generateTraceId() {
         Random random = new Random();
-        byte[] bytes = new byte[traceIdSizeInBytes]; // length will be length traceIdSizeInBytes * 2 hex chars
+        StringBuilder builder = new StringBuilder();
+
+        byte[] bytes = new byte[16]; // length will be length 32 hex chars
         random.nextBytes(bytes);
 
-        StringBuilder builder = new StringBuilder();
         for (byte b : bytes) {
             builder.append(String.format("%02x", b));
         }
@@ -69,7 +65,7 @@ public class TraceLogger {
      * Also propagates the trace context to servers.
      */
     public void startTrace() {
-        TraceContext.setTraceId(generateTraceId(TRACE_ID_SIZE_IN_BYTES));
+        TraceContext.setTraceId(generateTraceId());
     }
 
     /**

--- a/src/main/java/org/peergos/util/TraceLogger.java
+++ b/src/main/java/org/peergos/util/TraceLogger.java
@@ -24,7 +24,7 @@ public class TraceLogger {
     /**
      * Size of a traceId.
      */
-    private static final int TRACE_ID_SIZE_IN_BYTES = 16;
+    private static final int TRACE_ID_SIZE_IN_BYTES = 8;
 
     /**
      * Returns the singleton instance of the TraceLogger.
@@ -46,13 +46,13 @@ public class TraceLogger {
     }
 
     /**
-     * Generates a random Hex string of length 16 characters
+     * Generates a random Hex string of length traceIdSize * 2
      * 
      * @return traceId The randomly generated traceId.
      */
     public String generateTraceId(int traceIdSize) {
         Random random = new Random();
-        byte[] bytes = new byte[8]; // 8 bytes * 2 hex characters per byte = 16 hex characters
+        byte[] bytes = new byte[traceIdSize]; // length will be traceIdSize * 2 hex chars
         random.nextBytes(bytes);
 
         StringBuilder builder = new StringBuilder();


### PR DESCRIPTION
* Make trace id a 16 char hex string per Jaeger documentation: https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/trace/v1/trace.proto#L87-L93
* Make timestamps in Nanosecond format